### PR TITLE
Add some wallet endpoints; fix up FTX US auth headers

### DIFF
--- a/src/rest/model.rs
+++ b/src/rest/model.rs
@@ -265,5 +265,37 @@ pub struct Position {
 // REST API -> Wallet
 // TODO
 
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WalletDepositAddress {
+    pub address: String,
+    pub tag: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WalletBalance {
+    pub coin: String,
+    pub free: f64,
+    pub total: f64,
+    pub spot_borrow: f64,
+    pub available_without_borrow: f64,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WalletDeposit {
+    pub coin: String,
+    pub confirmations: usize,
+    pub confirmed_time: String,
+    pub fee: f64, // fee, not included in size
+    pub id: usize,
+    pub size: f64,
+    pub status: String, // "confirmed", "unconfirmed", or "cancelled"
+    pub time: String,
+    pub txid: Option<String>,
+    pub notes: Option<String>,
+}
+
 // REST API -> Orders
 // TODO

--- a/src/ws/mod.rs
+++ b/src/ws/mod.rs
@@ -82,6 +82,7 @@ impl Ws {
         Self::connect_with_endpoint(Self::ENDPOINT_US, key, secret).await
     }
 
+    /*
     async fn ping(&mut self) -> Result<()> {
         self.stream
             .send(Message::Text(
@@ -94,6 +95,7 @@ impl Ws {
 
         Ok(())
     }
+    */
 
     pub async fn subscribe(&mut self, channel: Channel, market: &str) -> Result<()> {
         self.stream


### PR DESCRIPTION
1. Add a couple of the wallet endpoints, eg:
```
    println!("deposit address: {:#?}", api.get_wallet_deposit_address("SOL", None).await.unwrap());
    println!("balances: {:#?}", api.get_wallet_balances().await.unwrap());
    println!("deposits: {:#?}", api.get_wallet_deposits(None, None, None).await.unwrap());
```
2. FTX US requires a slightly different authentication header prefix than FTX

Freebie: quash remaining rustc warning