### PR TITLE
Add basic Github Action's based CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,53 @@
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: stable
+        components: rustfmt, clippy
+
+    - uses: actions/cache@v2
+      with:
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+          target
+        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+    - name: cargo fmt
+      uses: actions-rs/cargo@v1
+      with:
+        command: fmt
+        args: --all -- --check
+
+    - name: cargo clippy
+      uses: actions-rs/cargo@v1
+      with:
+        command: clippy
+        args: --workspace --all-targets -- --deny=warnings
+
+    #- name: cargo test
+    #  uses: actions-rs/cargo@v1
+    #  with:
+    #    command: test
+    #    args: --verbose
+
+    - name: cargo build
+      uses: actions-rs/cargo@v1
+      with:
+        command: build
+

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,18 +28,22 @@ jobs:
           target
         key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
-    - name: cargo fmt
-      uses: actions-rs/cargo@v1
-      with:
-        command: fmt
-        args: --all -- --check
+    # TODO: Uncomment `cargo fmt` test once cargo fmt is run
+    #- name: cargo fmt
+    #  uses: actions-rs/cargo@v1
+    #  with:
+    #    command: fmt
+    #    args: --all -- --check
 
-    - name: cargo clippy
-      uses: actions-rs/cargo@v1
-      with:
-        command: clippy
-        args: --workspace --all-targets -- --deny=warnings
+    # TODO: Uncomment `cargo clippy` once all clippy lints are addressed
+    #- name: cargo clippy
+    #  uses: actions-rs/cargo@v1
+    #  with:
+    #    command: clippy
+    #    args: --workspace --all-targets -- --deny=warnings
 
+    # TODO: Uncomment `cargo test` if/when the tests can be run without the need for
+    #       an API key environment variable
     #- name: cargo test
     #  uses: actions-rs/cargo@v1
     #  with:


### PR DESCRIPTION
It makes me nervous sending PRs when there's no CI to check my work.  Here's a basic Github Action setup for rust crates. I've disabled a couple things for now:
1. `cargo fmt` -- there are still some files that don't fmt clean
2. `cargo clippy` -- a little bit of work needed to pacify clippy still!
3. `cargo test` -- the tests need an API key, so would fail in CI.

But hey, at least we can `cargo build` the crate.  Better than nothing!
Here's what the output of this looks like: https://github.com/mvines/ftx-test/actions/runs/824765662