### PR TITLE
Add support for subaccounts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,5 @@
 RUST_LOG=info
 API_KEY=<Insert your FTX API key, see https://ftx.com/profile>
 API_SECRET=<Insert your FTX API secret, see https://ftx.com/profile>
+# Uncomment this only if you are using subaccount-specific API keys
+# SUBACCOUNT=<Insert the nickname for your subaccount>

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 Cargo.lock
 .env
+.idea/

--- a/examples/btc_price.rs
+++ b/examples/btc_price.rs
@@ -9,7 +9,7 @@ async fn main() -> Result<()> {
     let api = Rest::new(
         var("API_KEY").expect("API Key is not defined."),
         var("API_SECRET").expect("API Secret is not defined."),
-        None,
+        var("SUBACCOUNT").ok(),
     );
 
     let price = api.get_market("BTC/USD").await?.price;

--- a/examples/get_account.rs
+++ b/examples/get_account.rs
@@ -1,12 +1,14 @@
 use ftx::rest::Rest;
 use std::env::var;
+use dotenv::dotenv;
 
 #[tokio::main]
 async fn main() {
+    dotenv().ok();
     let api = Rest::new(
         var("API_KEY").expect("API key not defined"),
         var("API_SECRET").expect("API secret not defined"),
-        None,
+        var("SUBACCOUNT").ok(),
     );
     println!("Account:");
     println!("{:#?}", api.get_account().await.unwrap());

--- a/src/ws/mod.rs
+++ b/src/ws/mod.rs
@@ -47,7 +47,12 @@ impl Ws {
     pub const ENDPOINT: &'static str = "wss://ftx.com/ws";
     pub const ENDPOINT_US: &'static str = "wss://ftx.us/ws";
 
-    async fn connect_with_endpoint(endpoint: &str, key: String, secret: String) -> Result<Self> {
+    async fn connect_with_endpoint(
+        endpoint: &str,
+        key: String,
+        secret: String,
+        subaccount: Option<String>
+    ) -> Result<Self> {
         let (mut stream, _) = connect_async(endpoint).await?;
 
         let timestamp = SystemTime::now()
@@ -66,6 +71,7 @@ impl Ws {
                         "key": key,
                         "sign": sign,
                         "time": timestamp as u64,
+                        "subaccount": subaccount,
                     }
                 })
                 .to_string(),
@@ -78,12 +84,12 @@ impl Ws {
         })
     }
 
-    pub async fn connect(key: String, secret: String) -> Result<Self> {
-        Self::connect_with_endpoint(Self::ENDPOINT, key, secret).await
+    pub async fn connect(key: String, secret: String, subaccount: Option<String>) -> Result<Self> {
+        Self::connect_with_endpoint(Self::ENDPOINT, key, secret, subaccount).await
     }
 
-    pub async fn connect_us(key: String, secret: String) -> Result<Self> {
-        Self::connect_with_endpoint(Self::ENDPOINT_US, key, secret).await
+    pub async fn connect_us(key: String, secret: String, subaccount: Option<String>) -> Result<Self> {
+        Self::connect_with_endpoint(Self::ENDPOINT_US, key, secret, subaccount).await
     }
 
     /*

--- a/src/ws/tests.rs
+++ b/src/ws/tests.rs
@@ -7,6 +7,7 @@ async fn init_ws() -> Ws {
     Ws::connect(
         var("API_KEY").expect("API Key is not defined."),
         var("API_SECRET").expect("API Secret is not defined."),
+        var("SUBACCOUNT").ok(),
     )
     .await
     .expect("Connection failed.")


### PR DESCRIPTION
**Summary:**
- Subaccount-specific API keys will now work with this library
- Specify the nickname of the account using the `API_SECRET` environment variable
- Integrated on both the websockets and REST API

Nice code! Thanks for implementing the websockets boilerplate - saved me a bunch of time.

One question: What is the intention behind the `read_only` function in the tests? My own project relies exclusively on subaccount-specific API keys and making it work with the current `read_only` implementation caused me some trouble.

I only started learning Rust last month, so I'm sure I could do some things better - please don't hesitate to leave feedback on style, nits, etc.

I also noticed that two of the `rest::tests` weren't passing on the `Future`s API calls. I fixed the bug and will open a separate PR for that just after this one.

Regards,
Max