### PR TITLE
Orderbooks via websockets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 Cargo.lock
 .env
 .idea/
+*.iml
+response.json

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ readme = "README.md"
 reqwest = { version = "^0.11.3", features = ["json"] }
 serde = { version = "^1.0.125", features = ["derive"] }
 serde_json = "^1.0.64"
+serde_with = { version = "^1.9.1", features = ["chrono"] }
 hmac-sha256 = "^0.1.7"
 dotenv = "^0.15.0"
 log = "^0.4.14"

--- a/examples/get_account.rs
+++ b/examples/get_account.rs
@@ -1,6 +1,6 @@
+use dotenv::dotenv;
 use ftx::rest::Rest;
 use std::env::var;
-use dotenv::dotenv;
 
 #[tokio::main]
 async fn main() {

--- a/src/rest/mod.rs
+++ b/src/rest/mod.rs
@@ -136,7 +136,7 @@ impl Rest {
         if let Some(subaccount) = &self.subaccount {
             headers.insert(
                 HeaderName::from_str(&format!("{}-SUBACCOUNT", self.header_prefix)).unwrap(),
-                HeaderValue::from_str(subaccount).unwrap()
+                HeaderValue::from_str(subaccount).unwrap(),
             );
         }
 

--- a/src/rest/tests.rs
+++ b/src/rest/tests.rs
@@ -14,7 +14,7 @@ async fn init_api() -> Rest {
     );
 
     // Test create subaccount only if credentials are account-wide
-    if let None = subaccount {
+    if subaccount.is_none() {
         read_only(api.create_subaccount("Bot").await);
     }
 
@@ -31,7 +31,8 @@ fn read_only<T>(result: Result<T>) {
 #[tokio::test]
 async fn get_subaccounts() {
     let rest = init_api().await;
-    if let None = rest.subaccount { // Test only if credentials are account-wide
+    if rest.subaccount.is_none() {
+        // Test only if credentials are account-wide
         rest.get_subaccounts().await.unwrap();
     }
 }
@@ -39,7 +40,8 @@ async fn get_subaccounts() {
 #[tokio::test]
 async fn create_subaccount() {
     let rest = init_api().await;
-    if let None = rest.subaccount { // Test only if credentials are account-wide
+    if rest.subaccount.is_none() {
+        // Test only if credentials are account-wide
         read_only(rest.create_subaccount("Bot").await);
     }
 }
@@ -47,7 +49,8 @@ async fn create_subaccount() {
 #[tokio::test]
 async fn change_subaccount_name() {
     let rest = init_api().await;
-    if let None = rest.subaccount { // Test only if credentials are account-wide
+    if rest.subaccount.is_none() {
+        // Test only if credentials are account-wide
         read_only(rest.change_subaccount_name("Bot", "Bot").await);
     }
 }
@@ -55,7 +58,8 @@ async fn change_subaccount_name() {
 #[tokio::test]
 async fn delete_subaccount() {
     let rest = init_api().await;
-    if let None = rest.subaccount { // Test only if credentials are account-wide
+    if rest.subaccount.is_none() {
+        // Test only if credentials are account-wide
         read_only(rest.delete_subaccount("Bot").await);
     }
 }
@@ -68,18 +72,15 @@ async fn get_subaccount_balances() {
         None => "Bot",
         Some(sub) => sub,
     };
-    rest
-        .get_subaccount_balances(&subaccount)
-        .await
-        .unwrap_err();
+    rest.get_subaccount_balances(&subaccount).await.unwrap_err();
 }
 
 #[tokio::test]
 async fn transfer_between_subaccounts() {
     let rest = init_api().await;
-    if let None = rest.subaccount { // Test only if credentials are account-wide
-        rest
-            .transfer_between_subaccounts("BTC", Decimal::zero(), "Source", "Destination")
+    if rest.subaccount.is_none() {
+        // Test only if credentials are account-wide
+        rest.transfer_between_subaccounts("BTC", Decimal::zero(), "Source", "Destination")
             .await
             .unwrap_err();
     }

--- a/src/ws/mod.rs
+++ b/src/ws/mod.rs
@@ -142,6 +142,7 @@ impl Ws {
         if let Some(msg) = self.stream.next().await {
             let msg = msg?;
             if let Message::Text(text) = msg {
+                // println!("{}", text); // Uncomment for debugging
                 return Ok(Some(serde_json::from_str(&text)?));
             }
         }

--- a/src/ws/mod.rs
+++ b/src/ws/mod.rs
@@ -169,8 +169,8 @@ impl Ws {
                             self.buf.push_back(Data::Trade(trade));
                         }
                     }
-                    ResponseData::OrderBookData(orderbook) => {
-                        self.buf.push_back(Data::OrderBookData(orderbook));
+                    ResponseData::OrderbookData(orderbook) => {
+                        self.buf.push_back(Data::OrderbookData(orderbook));
                     }
                 }
             }

--- a/src/ws/mod.rs
+++ b/src/ws/mod.rs
@@ -168,8 +168,8 @@ impl Ws {
                             self.buf.push_back(Data::Trade(trade));
                         }
                     }
-                    ResponseData::OrderBook(orderbook) => {
-                        self.buf.push_back(Data::OrderBook(orderbook));
+                    ResponseData::OrderBookData(orderbook) => {
+                        self.buf.push_back(Data::OrderBookData(orderbook));
                     }
                 }
             }

--- a/src/ws/mod.rs
+++ b/src/ws/mod.rs
@@ -51,7 +51,7 @@ impl Ws {
         endpoint: &str,
         key: String,
         secret: String,
-        subaccount: Option<String>
+        subaccount: Option<String>,
     ) -> Result<Self> {
         let (mut stream, _) = connect_async(endpoint).await?;
 
@@ -88,7 +88,11 @@ impl Ws {
         Self::connect_with_endpoint(Self::ENDPOINT, key, secret, subaccount).await
     }
 
-    pub async fn connect_us(key: String, secret: String, subaccount: Option<String>) -> Result<Self> {
+    pub async fn connect_us(
+        key: String,
+        secret: String,
+        subaccount: Option<String>,
+    ) -> Result<Self> {
         Self::connect_with_endpoint(Self::ENDPOINT_US, key, secret, subaccount).await
     }
 

--- a/src/ws/model.rs
+++ b/src/ws/model.rs
@@ -2,6 +2,7 @@ pub use crate::rest::{Coin, Id, MarketType, Side, Symbol};
 use chrono::{DateTime, Utc};
 use rust_decimal::Decimal;
 use serde::Deserialize;
+use serde_with::{serde_as, TimestampSecondsWithFrac};
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -64,9 +65,10 @@ pub struct Trade {
     pub size: Decimal,
     pub side: Side,
     pub liquidation: bool,
-    pub time: DateTime<Utc>,
+    pub time: DateTime<Utc>, // API returns "2021-05-23T05:24:24.315884+00:00"
 }
 
+#[serde_as]
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct OrderBook {
@@ -74,7 +76,8 @@ pub struct OrderBook {
     pub bids: Vec<[Decimal; 2]>,
     pub asks: Vec<[Decimal; 2]>,
     pub checksum: u32,
-    pub time: Decimal,
+    #[serde_as(as = "TimestampSecondsWithFrac<f64>")]
+    pub time: DateTime<Utc>, // API returns 1621740952.5079553
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/ws/model.rs
+++ b/src/ws/model.rs
@@ -46,12 +46,12 @@ pub enum Data {
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Trade {
-    id: Id,
-    price: Decimal,
-    size: Decimal,
-    side: Side,
-    liquidation: bool,
-    time: DateTime<Utc>,
+    pub id: Id,
+    pub price: Decimal,
+    pub size: Decimal,
+    pub side: Side,
+    pub liquidation: bool,
+    pub time: DateTime<Utc>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/ws/model.rs
+++ b/src/ws/model.rs
@@ -106,7 +106,7 @@ pub struct Orderbook {
 impl Orderbook {
     pub fn new(symbol: Symbol) -> Orderbook {
         Orderbook {
-            symbol: symbol,
+            symbol,
             bids: BTreeMap::new(),
             asks: BTreeMap::new(),
         }
@@ -121,7 +121,6 @@ impl Orderbook {
                 for ask in &data.asks {
                     self.asks.insert(ask.0, ask.1);
                 }
-
             }
             OrderbookAction::Update => {
                 for bid in &data.bids {
@@ -138,7 +137,6 @@ impl Orderbook {
                         self.asks.insert(ask.0, ask.1);
                     }
                 }
-
             }
         }
     }

--- a/src/ws/model.rs
+++ b/src/ws/model.rs
@@ -48,14 +48,14 @@ pub enum Type {
 #[serde(untagged)]
 pub enum ResponseData {
     Trades(Vec<Trade>),
-    OrderBookData(OrderBookData),
+    OrderbookData(OrderbookData),
 }
 
 /// Represents the data we return to the user
 #[derive(Debug)]
 pub enum Data {
     Trade(Trade),
-    OrderBookData(OrderBookData),
+    OrderbookData(OrderbookData),
 }
 
 #[derive(Debug, Deserialize)]
@@ -74,8 +74,8 @@ pub struct Trade {
 #[serde_as]
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct OrderBookData {
-    pub action: OrderBookAction,
+pub struct OrderbookData {
+    pub action: OrderbookAction,
     // Note that bids and asks are returned in 'best' order,
     // i.e. highest to lowest bids, lowest to highest asks
     pub bids: Vec<(Decimal, Decimal)>,
@@ -87,7 +87,7 @@ pub struct OrderBookData {
 
 #[derive(Debug, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
-pub enum OrderBookAction {
+pub enum OrderbookAction {
     /// Initial snapshot of the orderbook
     Partial,
     /// Updates to the orderbook
@@ -98,23 +98,23 @@ pub enum OrderBookAction {
 /// up to the best 100 bids and best 100 asks since the latest update.
 /// Supports efficient insertions, updates, and deletions via a BTreeMap.
 #[derive(Debug)]
-pub struct OrderBook {
+pub struct Orderbook {
     pub symbol: Symbol,
     pub bids: BTreeMap<Decimal, Decimal>,
     pub asks: BTreeMap<Decimal, Decimal>,
 }
-impl OrderBook {
-    pub fn new(symbol: Symbol) -> OrderBook {
-        OrderBook {
+impl Orderbook {
+    pub fn new(symbol: Symbol) -> Orderbook {
+        Orderbook {
             symbol: symbol,
             bids: BTreeMap::new(),
             asks: BTreeMap::new(),
         }
     }
 
-    pub fn update(&mut self, data: &OrderBookData) {
+    pub fn update(&mut self, data: &OrderbookData) {
         match data.action {
-            OrderBookAction::Partial => {
+            OrderbookAction::Partial => {
                 for bid in &data.bids {
                     self.bids.insert(bid.0, bid.1);
                 }
@@ -123,7 +123,7 @@ impl OrderBook {
                 }
 
             }
-            OrderBookAction::Update => {
+            OrderbookAction::Update => {
                 for bid in &data.bids {
                     if bid.1 == Decimal::from(0) {
                         self.bids.remove(&bid.0);

--- a/src/ws/model.rs
+++ b/src/ws/model.rs
@@ -99,12 +99,14 @@ pub enum OrderBookAction {
 /// Supports efficient insertions, updates, and deletions via a BTreeMap.
 #[derive(Debug)]
 pub struct OrderBook {
+    pub symbol: Symbol,
     pub bids: BTreeMap<Decimal, Decimal>,
     pub asks: BTreeMap<Decimal, Decimal>,
 }
 impl OrderBook {
-    pub fn new() -> OrderBook {
+    pub fn new(symbol: Symbol) -> OrderBook {
         OrderBook {
+            symbol: symbol,
             bids: BTreeMap::new(),
             asks: BTreeMap::new(),
         }

--- a/src/ws/model.rs
+++ b/src/ws/model.rs
@@ -111,6 +111,37 @@ impl OrderBook {
             asks: BTreeMap::new(),
         }
     }
+
+    pub fn update(&mut self, data: &OrderBookData) {
+        match data.action {
+            OrderBookAction::Partial => {
+                for bid in &data.bids {
+                    self.bids.insert(bid.0, bid.1);
+                }
+                for ask in &data.asks {
+                    self.asks.insert(ask.0, ask.1);
+                }
+
+            }
+            OrderBookAction::Update => {
+                for bid in &data.bids {
+                    if bid.1 == Decimal::from(0) {
+                        self.bids.remove(&bid.0);
+                    } else {
+                        self.bids.insert(bid.0, bid.1);
+                    }
+                }
+                for ask in &data.asks {
+                    if ask.1 == Decimal::from(0) {
+                        self.asks.remove(&ask.0);
+                    } else {
+                        self.asks.insert(ask.0, ask.1);
+                    }
+                }
+
+            }
+        }
+    }
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/ws/model.rs
+++ b/src/ws/model.rs
@@ -25,7 +25,7 @@ pub struct Response {
 pub struct Response {
     pub market: Symbol,
     pub r#type: Type,
-    pub data: Option<Vec<Data>>,
+    pub data: Option<ResponseData>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -34,13 +34,26 @@ pub enum Type {
     Subscribed,
     Update,
     Error,
+    Partial,
+    // Unsubscribed, // May need this in the future
+    // Info,         // May need this in the future
 }
 
+/// This represents the response received from FTX, and is used for
+/// deserialization
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 #[serde(untagged)]
+pub enum ResponseData {
+    Trades(Vec<Trade>),
+    OrderBook(OrderBook),
+}
+
+/// This represents the data we return to the user
+#[derive(Debug)]
 pub enum Data {
     Trade(Trade),
+    OrderBook(OrderBook),
 }
 
 #[derive(Debug, Deserialize)]
@@ -52,6 +65,25 @@ pub struct Trade {
     pub side: Side,
     pub liquidation: bool,
     pub time: DateTime<Utc>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct OrderBook {
+    pub action: OrderBookAction,
+    pub bids: Vec<[Decimal; 2]>,
+    pub asks: Vec<[Decimal; 2]>,
+    pub checksum: u32,
+    pub time: Decimal,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum OrderBookAction {
+    /// Initial snapshot of the orderbook
+    Partial,
+    /// Updates to the orderbook
+    Update,
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/ws/tests.rs
+++ b/src/ws/tests.rs
@@ -1,6 +1,7 @@
 use super::*;
 use dotenv::dotenv;
 use std::env::var;
+use rust_decimal::Decimal;
 
 async fn init_ws() -> Ws {
     dotenv().ok();
@@ -37,19 +38,48 @@ async fn order_book() {
         .await
         .expect("Subscription failed.");
 
-    // The initial snapshot of the data
+    // The initial snapshot of the order book
     match ws.next().await.unwrap() {
-        Some(Data::OrderBookData(orderbook_data))
-        if orderbook_data.action == OrderBookAction::Partial => {
+        Some(Data::OrderBookData(data))
 
-            for bid in &orderbook_data.bids {
+        if data.action == OrderBookAction::Partial => {
+            for bid in &data.bids {
                 orderbook.bids.insert(bid.0, bid.1);
             }
-            for ask in &orderbook_data.asks {
+            for ask in &data.asks {
                 orderbook.asks.insert(ask.0, ask.1);
             }
             // println!("{:#?}", orderbook);
         }
         _ => panic!("Order book snapshot data expected."),
+    }
+
+    // Update the order book 10 times
+    for _i in 1..10 {
+        match ws.next().await.unwrap() {
+            Some(Data::OrderBookData(data))
+            if data.action == OrderBookAction::Update => {
+                for bid in &data.bids {
+                    // Remove the bid
+                    if bid.1 == Decimal::from(0) {
+                        assert!(orderbook.bids.contains_key(&bid.0));
+                        assert!(orderbook.bids.remove(&bid.0).is_some());
+                    } else {
+                        orderbook.bids.insert(bid.0, bid.1);
+                    }
+                }
+                for ask in &data.asks {
+                    // Remove the ask
+                    if ask.1 == Decimal::from(0) {
+                        assert!(orderbook.asks.contains_key(&ask.0));
+                        assert!(orderbook.asks.remove(&ask.0).is_some());
+                    } else {
+                        orderbook.asks.insert(ask.0, ask.1);
+                    }
+                }
+                // println!("{:#?}", orderbook);
+            }
+            _ => panic!("Order book update data expected."),
+        }
     }
 }

--- a/src/ws/tests.rs
+++ b/src/ws/tests.rs
@@ -1,7 +1,7 @@
 use super::*;
 use dotenv::dotenv;
-use std::env::var;
 use rust_decimal::Decimal;
+use std::env::var;
 
 async fn init_ws() -> Ws {
     dotenv().ok();
@@ -30,7 +30,6 @@ async fn trades() {
 
 #[tokio::test]
 async fn order_book() {
-
     let mut ws = init_ws().await;
 
     let symbol: Symbol = String::from("BTC-PERP");
@@ -42,9 +41,7 @@ async fn order_book() {
 
     // The initial snapshot of the order book
     match ws.next().await.unwrap() {
-        Some(Data::OrderbookData(data))
-
-        if data.action == OrderbookAction::Partial => {
+        Some(Data::OrderbookData(data)) if data.action == OrderbookAction::Partial => {
             orderbook.update(&data);
             // println!("{:#?}", orderbook);
         }
@@ -54,9 +51,7 @@ async fn order_book() {
     // Update the order book 10 times
     for _i in 1..10 {
         match ws.next().await.unwrap() {
-            Some(Data::OrderbookData(data))
-            if data.action == OrderbookAction::Update => {
-
+            Some(Data::OrderbookData(data)) if data.action == OrderbookAction::Update => {
                 // Check that removed orders are in the orderbook
                 for bid in &data.bids {
                     if bid.1 == Decimal::from(0) {

--- a/src/ws/tests.rs
+++ b/src/ws/tests.rs
@@ -29,16 +29,27 @@ async fn trades() {
 
 #[tokio::test]
 async fn order_book() {
+    let mut orderbook = OrderBook::new();
+
     let mut ws = init_ws().await;
 
     ws.subscribe(vec![Channel::Orderbook("BTC-PERP".to_owned())])
         .await
         .expect("Subscription failed.");
 
+    // The initial snapshot of the data
     match ws.next().await.unwrap() {
-        Some(Data::OrderBook(orderbook)) => {
-            println!("{:?}", orderbook.time);
+        Some(Data::OrderBookData(orderbook_data))
+        if orderbook_data.action == OrderBookAction::Partial => {
+
+            for bid in &orderbook_data.bids {
+                orderbook.bids.insert(bid.0, bid.1);
+            }
+            for ask in &orderbook_data.asks {
+                orderbook.asks.insert(ask.0, ask.1);
+            }
+            // println!("{:#?}", orderbook);
         }
-        _ => panic!("Order book data expected."),
+        _ => panic!("Order book snapshot data expected."),
     }
 }

--- a/src/ws/tests.rs
+++ b/src/ws/tests.rs
@@ -36,7 +36,9 @@ async fn order_book() {
         .expect("Subscription failed.");
 
     match ws.next().await.unwrap() {
-        Some(Data::OrderBook(orderbook)) => {}
+        Some(Data::OrderBook(orderbook)) => {
+            println!("{:?}", orderbook.time);
+        }
         _ => panic!("Order book data expected."),
     }
 }

--- a/src/ws/tests.rs
+++ b/src/ws/tests.rs
@@ -38,13 +38,13 @@ async fn order_book() {
         .await
         .expect("Subscription failed.");
 
-    let mut orderbook = OrderBook::new(symbol);
+    let mut orderbook = Orderbook::new(symbol);
 
     // The initial snapshot of the order book
     match ws.next().await.unwrap() {
-        Some(Data::OrderBookData(data))
+        Some(Data::OrderbookData(data))
 
-        if data.action == OrderBookAction::Partial => {
+        if data.action == OrderbookAction::Partial => {
             orderbook.update(&data);
             // println!("{:#?}", orderbook);
         }
@@ -54,10 +54,10 @@ async fn order_book() {
     // Update the order book 10 times
     for _i in 1..10 {
         match ws.next().await.unwrap() {
-            Some(Data::OrderBookData(data))
-            if data.action == OrderBookAction::Update => {
+            Some(Data::OrderbookData(data))
+            if data.action == OrderbookAction::Update => {
 
-                // Check that cancelled orders are in the orderbook
+                // Check that removed orders are in the orderbook
                 for bid in &data.bids {
                     if bid.1 == Decimal::from(0) {
                         assert!(orderbook.bids.contains_key(&bid.0));
@@ -72,7 +72,7 @@ async fn order_book() {
                 // Update the order book
                 orderbook.update(&data);
 
-                // Check that cancelled orders are no longer in the orderbook
+                // Check that removed orders are no longer in the orderbook
                 // Check that inserted orders have been updated correctly
                 for bid in &data.bids {
                     if bid.1 == Decimal::from(0) {

--- a/src/ws/tests.rs
+++ b/src/ws/tests.rs
@@ -26,3 +26,17 @@ async fn trades() {
         _ => panic!("Trade data expected."),
     }
 }
+
+#[tokio::test]
+async fn order_book() {
+    let mut ws = init_ws().await;
+
+    ws.subscribe(vec![Channel::Orderbook("BTC-PERP".to_owned())])
+        .await
+        .expect("Subscription failed.");
+
+    match ws.next().await.unwrap() {
+        Some(Data::OrderBook(orderbook)) => {}
+        _ => panic!("Order book data expected."),
+    }
+}

--- a/src/ws/tests.rs
+++ b/src/ws/tests.rs
@@ -30,13 +30,15 @@ async fn trades() {
 
 #[tokio::test]
 async fn order_book() {
-    let mut orderbook = OrderBook::new();
 
     let mut ws = init_ws().await;
 
-    ws.subscribe(vec![Channel::Orderbook("BTC-PERP".to_owned())])
+    let symbol: Symbol = String::from("BTC-PERP");
+    ws.subscribe(vec![Channel::Orderbook(symbol.to_owned())])
         .await
         .expect("Subscription failed.");
+
+    let mut orderbook = OrderBook::new(symbol);
 
     // The initial snapshot of the order book
     match ws.next().await.unwrap() {


### PR DESCRIPTION
### Summary
This PR implements most of the functionality for order books for the Websockets API.

### Notable changes:
- Made the `Trade` fields public so they can be used in applications
- Had to add a new `ResponseData` enum in addition to the `Data` enum. When listening for trades, the FTX API returns `Vec<Trade>`, but when listening for order book updates, the API just returns the `OrderBookUpdate`. Meanwhile, `Ws` intends to send individual trades back to the user rather than `Vec<Trade>`. With this pull request, `Data` will still represent what we return to users, while `ResponseData` is used instead for deserializing what is returned from the FTX API.
- Created an `OrderBook` struct that one's current view of the order book. Includes higher level functionality for updating its state using the `OrderBookData` received from the API. Handling the `OrderBookData` is somewhat non-trivial, so I implemented it to save users some trouble. If the implementing code should go somewhere other than `models.rs` please let me know.
- Added a test which covers the basic functionality of order book initialization and updates.

### Issue: Checksum verification
I am currently struggling with the verification of order book checksums. I implemented the verification function in [this commit](https://github.com/MaxFangX/ftx/commit/435490b5649fe630c11a1939f1c6960ed04eb849) (not included in this PR) but for some reason the final output does not match the checksum returned by FTX. One possible discrepancy is that the [documentation](https://docs.ftx.com/?python#orderbooks) says that the CRC32 checksum is a **signed** 32-bit integer, while all the libraries and standards seem to point to CRC32 being an **unsigned** 32-bit integer. I tried both `i32` and `u32` for the deserialization type of the checksum field, but couldn't get the checksums to match. Any pointers would be appreciated.