### PR TITLE
Add remaining parameters for Rest::place_order

### DIFF
--- a/src/rest/error.rs
+++ b/src/rest/error.rs
@@ -4,6 +4,7 @@ pub type Result<T> = std::result::Result<T, Error>;
 pub enum Error {
     Reqwest(reqwest::Error),
     Api(String),
+    PlacingLimitOrderRequiresPrice,
 }
 
 impl From<reqwest::Error> for Error {

--- a/src/rest/mod.rs
+++ b/src/rest/mod.rs
@@ -419,9 +419,9 @@ impl Rest {
                 "price": if let OrderType::Limit = r#type { price } else { None },
                 "type": r#type,
                 "size": size,
-                "reduceOnly": reduce_only,
-                "ioc": ioc,
-                "postOnly": post_only,
+                "reduceOnly": reduce_only.unwrap_or(false),
+                "ioc": ioc.unwrap_or(false),
+                "postOnly": post_only.unwrap_or(false),
                 "clientId": client_id,
             })),
         )


### PR DESCRIPTION
This makes the `reduceOnly`, `ioc`, and `postOnly` parameters usable by applications. 