### PR TITLE
Websockets: Ping every 15 seconds

### DIFF
--- a/examples/watch_market.rs
+++ b/examples/watch_market.rs
@@ -35,7 +35,6 @@ async fn main() -> Result<()> {
                     "\n{:?} {} {} at {} - liquidation = {}",
                     trade.side, trade.size, market, trade.price, trade.liquidation
                 );
-                println!("\n{:?}", trade)
             }
             Data::OrderbookData(orderbook_data) => {
                 orderbook.update(&orderbook_data);

--- a/examples/watch_market.rs
+++ b/examples/watch_market.rs
@@ -1,0 +1,48 @@
+use dotenv::dotenv;
+use ftx::ws::Result;
+use ftx::ws::{Channel, Data, Orderbook, Ws};
+use std::env::var;
+use std::io;
+use std::io::Write;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    dotenv().ok();
+
+    let mut websocket = Ws::connect(
+        var("API_KEY").expect("API Key is not defined."),
+        var("API_SECRET").expect("API Secret is not defined."),
+        var("SUBACCOUNT").ok(),
+    )
+    .await?;
+
+    let market = String::from("BTC-PERP");
+    let mut orderbook = Orderbook::new(market.to_owned());
+
+    websocket
+        .subscribe(vec![
+            Channel::Trades(market.to_owned()),
+            Channel::Orderbook(market.to_owned()),
+        ])
+        .await?;
+
+    loop {
+        let data = websocket.next().await?.expect("No data received");
+
+        match data {
+            Data::Trade(trade) => {
+                println!(
+                    "\n{:?} {} {} at {} - liquidation = {}",
+                    trade.side, trade.size, market, trade.price, trade.liquidation
+                );
+                println!("\n{:?}", trade)
+            }
+            Data::OrderbookData(orderbook_data) => {
+                orderbook.update(&orderbook_data);
+                print!("."); // To signify orderbook update
+                io::stdout().flush().unwrap(); // Emits the output immediately
+            }
+            _ => panic!("Unexpected data type"),
+        }
+    }
+}

--- a/src/ws/mod.rs
+++ b/src/ws/mod.rs
@@ -59,12 +59,10 @@ impl Ws {
             ))
             .await?;
 
-        let ping_timer = time::interval(Duration::from_secs(15));
-
         Ok(Self {
             stream,
             buf: VecDeque::new(),
-            ping_timer,
+            ping_timer: time::interval(Duration::from_secs(15)),
         })
     }
 

--- a/src/ws/model.rs
+++ b/src/ws/model.rs
@@ -38,6 +38,7 @@ pub enum Type {
     Update,
     Error,
     Partial,
+    Pong,
     // Unsubscribed, // May need this in the future
     // Info,         // May need this in the future
 }


### PR DESCRIPTION
### Summary
- Added `examples/watchmarket` which uses the full functionality of what is currently implemented in the websockets API, which can be helpful boilerplate for developers less familiar with the codebase. It's also the only realistic way to test a ping that occurs only once every 15 seconds
- Implemented the main functionality as a `select!` between two streams: 
    1. the original websockets stream
    2. a `ping_timer` stream which polls to Ready every 15 seconds.

I felt that implementing this in the internals of the `Ws` object was ideal because it saves the user from having to implement this non-trivial code themselves. However, this code does assume that the user is usually `await`ing on `next()` - so long as that the case, the `Ws` object will continue to send pings and keep the connection alive.

### Refactor
I had to refactor the code a bit so that the two branches of `select!` could access `self.ping_timer.tick()` and `self.stream.next()` directly. Trying to `select!` on `self.next_internal` required a mutable reference which conflicted with `self.ping_timer.tick()`.

![Screen Shot 2021-05-30 at 9 29 53 AM](https://user-images.githubusercontent.com/7884003/120122351-22820e00-c15d-11eb-83f0-d4af87133d87.png)

Trying to bypass this with `let` statements only produced more errors - difficult ones too.

![Screen Shot 2021-05-30 at 9 03 07 AM](https://user-images.githubusercontent.com/7884003/120122366-362d7480-c15d-11eb-9568-a40777cf5d1a.png)
![Screen Shot 2021-05-30 at 9 18 44 AM](https://user-images.githubusercontent.com/7884003/120122415-68d76d00-c15d-11eb-803f-8060a963a97a.png)
![Screen Shot 2021-05-30 at 9 00 51 AM](https://user-images.githubusercontent.com/7884003/120122383-4f362580-c15d-11eb-822f-1cb43ff64cf0.png)

Since the main purpose of `next_internal()` was to provide a way for `subscribe()` to check for subscription confirmation, I figured this could be served with a `next_response` function which can be called directly by `subscribe()` or which could be processed further within `next()` with the help of a synchronous `handle_response` function that takes the response and adds its contents to the buffer. `next()` will now keep listening to the websockets API and handling `Pong` responses until it detects that the buffer contains a `Data` item that can be returned to the user.