### PR TITLE
Orderbook convenience methods

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ dotenv = "^0.15.0"
 log = "^0.4.14"
 hex = "^0.4.3"
 rust_decimal = "^1.13.0"
+rust_decimal_macros = "^1.14.1"
 chrono = { version = "^0.4.19", features = ["serde"] }
 tokio-tungstenite = { version = "^0.14.0", features = ["native-tls"], optional = true }
 futures-util = { version = "^0.3.14", optional = true }

--- a/src/ws/error.rs
+++ b/src/ws/error.rs
@@ -6,6 +6,7 @@ pub type Result<T> = std::result::Result<T, Error>;
 pub enum Error {
     Tungstenite(tungstenite::Error),
     Serde(serde_json::Error),
+    MissingSubscriptionConfirmation,
 }
 
 impl From<tungstenite::Error> for Error {

--- a/src/ws/mod.rs
+++ b/src/ws/mod.rs
@@ -116,7 +116,7 @@ impl Ws {
                     r#type: Type::Subscribed,
                     ..
                 } => {}
-                _ => panic!("Subscription confirmation expected."),
+                _ => return Err(Error::MissingSubscriptionConfirmation),
             }
         }
 


### PR DESCRIPTION
Added methods that make it easier to work with the order book, and associated tests:
- `bid_price`
- `ask_price`
- `mid_price`
- `best_bid`
- `best_ask`
- `best_bid_and_ask`
- `quote`

Also replaced the `panic!` while waiting for subscription confirmation with an error so library users to recover from it.

