### PR TITLE
Unify all floats to Decimal, ids to Id

### DIFF
--- a/src/rest/mod.rs
+++ b/src/rest/mod.rs
@@ -395,9 +395,9 @@ impl Rest {
         &self,
         market: &str,
         side: OrderSide,
-        price: Option<f64>,
+        price: Option<Decimal>,
         r#type: OrderType,
-        size: f64,
+        size: Decimal,
         reduce_only: Option<bool>,
         ioc: Option<bool>,
         post_only: Option<bool>,
@@ -431,8 +431,8 @@ impl Rest {
     pub async fn modify_order(
         &self,
         order_id: usize,
-        price: Option<f64>,
-        size: Option<f64>,
+        price: Option<Decimal>,
+        size: Option<Decimal>,
         client_id: Option<&str>,
     ) -> Result<OrderInfo> {
         self.post(

--- a/src/rest/mod.rs
+++ b/src/rest/mod.rs
@@ -430,7 +430,7 @@ impl Rest {
 
     pub async fn modify_order(
         &self,
-        order_id: usize,
+        order_id: Id,
         price: Option<Decimal>,
         size: Option<Decimal>,
         client_id: Option<&str>,
@@ -446,7 +446,7 @@ impl Rest {
         .await
     }
 
-    pub async fn get_order(&self, order_id: usize) -> Result<OrderInfo> {
+    pub async fn get_order(&self, order_id: Id) -> Result<OrderInfo> {
         self.get(&format!("/orders/{}", order_id), None).await
     }
 
@@ -455,7 +455,7 @@ impl Rest {
             .await
     }
 
-    pub async fn cancel_order(&self, order_id: usize) -> Result<String> {
+    pub async fn cancel_order(&self, order_id: Id) -> Result<String> {
         self.delete(&format!("/orders/{}", order_id), None).await
     }
 

--- a/src/rest/model.rs
+++ b/src/rest/model.rs
@@ -301,7 +301,7 @@ pub struct WalletDeposit {
     pub confirmations: usize,
     pub confirmed_time: String,
     pub fee: Decimal, // fee, not included in size
-    pub id: usize,
+    pub id: Id,
     pub size: Decimal,
     pub status: DepositStatus,
     pub time: String,
@@ -337,7 +337,7 @@ pub enum OrderStatus {
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct OrderInfo {
-    pub id: usize,
+    pub id: Id,
     pub market: String,
     pub future: Option<String>,
     pub r#type: OrderType,

--- a/src/rest/model.rs
+++ b/src/rest/model.rs
@@ -277,13 +277,13 @@ pub struct WalletDepositAddress {
 #[serde(rename_all = "camelCase")]
 pub struct WalletBalance {
     pub coin: String,
-    pub free: f64,
-    pub total: f64,
-    pub spot_borrow: f64,
-    pub available_without_borrow: f64,
+    pub free: Decimal,
+    pub total: Decimal,
+    pub spot_borrow: Decimal,
+    pub available_without_borrow: Decimal,
     /// As of 2021-05-12, usdValue is not documented on
     /// https://docs.ftx.com/#get-balances, but it is returned.
-    pub usd_value: Option<f64>,
+    pub usd_value: Option<Decimal>,
 }
 
 #[derive(Debug, Deserialize, PartialEq)]
@@ -300,9 +300,9 @@ pub struct WalletDeposit {
     pub coin: String,
     pub confirmations: usize,
     pub confirmed_time: String,
-    pub fee: f64, // fee, not included in size
+    pub fee: Decimal, // fee, not included in size
     pub id: usize,
-    pub size: f64,
+    pub size: Decimal,
     pub status: DepositStatus,
     pub time: String,
     pub txid: Option<String>,
@@ -342,15 +342,15 @@ pub struct OrderInfo {
     pub future: Option<String>,
     pub r#type: OrderType,
     pub side: OrderSide,
-    pub price: Option<f64>, // null for new market orders
-    pub size: f64,
+    pub price: Option<Decimal>, // null for new market orders
+    pub size: Decimal,
     pub reduce_only: bool,
     pub ioc: bool,
     pub post_only: bool,
     pub status: OrderStatus,
-    pub filled_size: f64,
-    pub remaining_size: f64,
-    pub avg_fill_price: Option<f64>,
+    pub filled_size: Decimal,
+    pub remaining_size: Decimal,
+    pub avg_fill_price: Option<Decimal>,
     pub liquidation: Option<bool>,
     pub created_at: DateTime<Utc>,
     pub client_id: Option<String>,

--- a/src/ws/model.rs
+++ b/src/ws/model.rs
@@ -269,7 +269,7 @@ impl Orderbook {
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Fill {
-    pub id: usize,
+    pub id: Id,
     pub market: Symbol,
     pub future: Option<Symbol>,
     pub base_currency: Option<Coin>,
@@ -278,8 +278,8 @@ pub struct Fill {
     pub side: Side,
     pub price: Decimal,
     pub size: Decimal,
-    pub order_id: usize,
-    pub trade_id: usize,
+    pub order_id: Id,
+    pub trade_id: Id,
     pub time: DateTime<Utc>,
     pub fee: Decimal,
     pub fee_rate: Decimal,

--- a/src/ws/model.rs
+++ b/src/ws/model.rs
@@ -269,7 +269,7 @@ impl Orderbook {
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Fill {
-    pub id: u64,
+    pub id: usize,
     pub market: Symbol,
     pub future: Option<Symbol>,
     pub base_currency: Option<Coin>,
@@ -278,8 +278,8 @@ pub struct Fill {
     pub side: Side,
     pub price: Decimal,
     pub size: Decimal,
-    pub order_id: u64,
-    pub trade_id: u64,
+    pub order_id: usize,
+    pub trade_id: usize,
     pub time: DateTime<Utc>,
     pub fee: Decimal,
     pub fee_rate: Decimal,

--- a/src/ws/tests.rs
+++ b/src/ws/tests.rs
@@ -226,7 +226,7 @@ async fn fills() {
         OrderSide::Buy,
         None,
         OrderType::Market,
-        0.0001,
+        dec!(0.0001),
         None,
         None,
         None,


### PR DESCRIPTION
Not using `Decimal` and `usize` throughout is causing some issues when trying to compare the same semantic value across different structs. For example, `OrderInfo.id` is a `usize` while `Fill.order_id` is a `u64`, which cannot be compared directly. This PR changes unifies all floats into `Decimal` and all integer values into `usize` so that types for values with the same semantic meaning can be consistent across structs.