### PR TITLE
Derive Copy, Clone for most simple enums

### DIFF
--- a/src/rest/model.rs
+++ b/src/rest/model.rs
@@ -110,7 +110,7 @@ pub struct Orderbook {
     pub bids: Vec<(Decimal, Decimal)>,
 }
 
-#[derive(Debug, Deserialize, PartialEq)]
+#[derive(Copy, Clone, Debug, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub enum Side {
     Buy,
@@ -145,7 +145,7 @@ pub type Prices = Vec<Price>;
 
 // REST API -> Futures
 
-#[derive(Debug, Deserialize, PartialEq)]
+#[derive(Copy, Clone, Debug, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub enum FutureType {
     Future,
@@ -286,7 +286,7 @@ pub struct WalletBalance {
     pub usd_value: Option<Decimal>,
 }
 
-#[derive(Debug, Deserialize, PartialEq)]
+#[derive(Copy, Clone, Debug, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub enum DepositStatus {
     Confirmed,
@@ -312,21 +312,21 @@ pub struct WalletDeposit {
 // REST API -> Orders
 // TODO
 
-#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Copy, Clone, Debug, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub enum OrderType {
     Market,
     Limit,
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Copy, Clone, Debug, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub enum OrderSide {
     Buy,
     Sell,
 }
 
-#[derive(Debug, Deserialize, PartialEq)]
+#[derive(Copy, Clone, Debug, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub enum OrderStatus {
     New, // accepted but not processed yet

--- a/src/ws/model.rs
+++ b/src/ws/model.rs
@@ -92,7 +92,7 @@ pub struct OrderbookData {
 }
 type Checksum = u32;
 
-#[derive(Debug, Deserialize, PartialEq)]
+#[derive(Copy, Clone, Debug, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub enum OrderbookAction {
     /// Initial snapshot of the orderbook
@@ -287,7 +287,7 @@ pub struct Fill {
     pub liquidity: Liquidity,
 }
 
-#[derive(Debug, Deserialize, PartialEq)]
+#[derive(Copy, Clone, Debug, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub enum Liquidity {
     Maker,


### PR DESCRIPTION
I ran into this requirement trying to call `place_order` repeatedly inside a loop. My project code basically goes like this:
```
let side = ... // assign side based on some other logic
loop {
    api.place_order(..., side);
}
```
And the error:
![Screen Shot 2021-06-09 at 1 07 34 PM](https://user-images.githubusercontent.com/7884003/121422052-aa1d0900-c923-11eb-9e76-a1fd35b0fbb7.png)

I can't derive or implement the `Copy` trait on `OrderSide` in my own project since `OrderSide` is defined inside this crate.

Since I ran into this issue I figured I should derive `Copy` (and `Clone`, required by `Copy`) for most of the simple enums in the `ftx` library - "simple" as in there are no values attached to the enum variants. I left out a couple in the `ws` module where I couldn't see any plausible use case for using those enum variants inside a variable, such as `ws::Type` which tracks the type of the message received from the websocket.
