### PR TITLE
Unsubscribe from websockets

### DIFF
--- a/src/ws/error.rs
+++ b/src/ws/error.rs
@@ -1,3 +1,4 @@
+use crate::ws::Channel;
 use tokio_tungstenite::tungstenite;
 
 pub type Result<T> = std::result::Result<T, Error>;
@@ -6,6 +7,7 @@ pub type Result<T> = std::result::Result<T, Error>;
 pub enum Error {
     Tungstenite(tungstenite::Error),
     Serde(serde_json::Error),
+    NotSubscribedToThisChannel(Channel),
     MissingSubscriptionConfirmation,
 }
 

--- a/src/ws/mod.rs
+++ b/src/ws/mod.rs
@@ -173,7 +173,7 @@ impl Ws {
                     }
                     _ => {
                         // Otherwise, continue adding contents to buffer
-                        self.handle_response(response)?;
+                        self.handle_response(response);
                     }
                 }
             }
@@ -209,7 +209,7 @@ impl Ws {
     }
 
     /// Helper function that takes a response and adds the contents to the buffer
-    fn handle_response(&mut self, response: Response) -> Result<()> {
+    fn handle_response(&mut self, response: Response) {
         if let Some(data) = response.data {
             match data {
                 ResponseData::Trades(trades) => {
@@ -227,8 +227,6 @@ impl Ws {
                 }
             }
         }
-
-        Ok(())
     }
 
     pub async fn next(&mut self) -> Result<Option<Data>> {
@@ -242,7 +240,7 @@ impl Ws {
             let response = self.next_response().await?;
 
             // Handle the response, possibly adding to the buffer
-            self.handle_response(response)?;
+            self.handle_response(response);
         }
     }
 }

--- a/src/ws/mod.rs
+++ b/src/ws/mod.rs
@@ -106,10 +106,18 @@ impl Ws {
 
     /// Unsubscribe from specified `Channel`s
     pub async fn unsubscribe(&mut self, channels: Vec<Channel>) -> Result<()> {
-        // Remove specified channels from self.channels
-        self.channels.retain(|c| !channels.contains(c));
+        // Check that the specified channels match an existing one
+        for channel in channels.iter() {
+            if !self.channels.contains(&channel) {
+                return Err(Error::NotSubscribedToThisChannel(channel.clone()));
+            }
+        }
 
-        self.subscribe_or_unsubscribe(channels, false).await?;
+        self.subscribe_or_unsubscribe(channels.clone(), false)
+            .await?;
+
+        // Unsubscribe successful, remove specified channels from self.channels
+        self.channels.retain(|c| !channels.contains(c));
 
         Ok(())
     }

--- a/src/ws/model.rs
+++ b/src/ws/model.rs
@@ -37,11 +37,11 @@ pub struct Response {
 #[serde(rename_all = "camelCase")]
 pub enum Type {
     Subscribed,
+    Unsubscribed,
     Update,
     Error,
     Partial,
     Pong,
-    // Unsubscribed, // May need this in the future
     // Info,         // May need this in the future
 }
 

--- a/src/ws/model.rs
+++ b/src/ws/model.rs
@@ -7,7 +7,7 @@ use serde::Deserialize;
 use serde_with::{serde_as, TimestampSecondsWithFrac};
 use std::collections::BTreeMap;
 
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub enum Channel {
     Orderbook(Symbol),

--- a/src/ws/tests.rs
+++ b/src/ws/tests.rs
@@ -83,7 +83,7 @@ async fn order_book_update() {
     match ws.next().await.unwrap() {
         Some(Data::OrderbookData(data)) if data.action == OrderbookAction::Partial => {
             orderbook.update(&data);
-            assert_eq!(orderbook.verify_checksum(data.checksum), true);
+            assert!(orderbook.verify_checksum(data.checksum));
             // println!("{:#?}", orderbook);
         }
         _ => panic!("Order book snapshot data expected."),
@@ -107,20 +107,20 @@ async fn order_book_update() {
 
                 // Update the order book
                 orderbook.update(&data);
-                assert_eq!(orderbook.verify_checksum(data.checksum), true);
+                assert!(orderbook.verify_checksum(data.checksum));
 
                 // Check that removed orders are no longer in the orderbook
                 // Check that inserted orders have been updated correctly
                 for bid in &data.bids {
                     if bid.1 == dec!(0) {
-                        assert_eq!(orderbook.bids.contains_key(&bid.0), false);
+                        assert!(orderbook.bids.contains_key(&bid.0));
                     } else {
                         assert_eq!(orderbook.bids.get(&bid.0), Some(&bid.1));
                     }
                 }
                 for ask in &data.asks {
                     if ask.1 == dec!(0) {
-                        assert_eq!(orderbook.asks.contains_key(&ask.0), false);
+                        assert!(!orderbook.asks.contains_key(&ask.0));
                     } else {
                         assert_eq!(orderbook.asks.get(&ask.0), Some(&ask.1));
                     }
@@ -222,7 +222,7 @@ async fn order_book_checksum() {
         match ws.next().await.unwrap() {
             Some(Data::OrderbookData(data)) if data.action == OrderbookAction::Partial => {
                 orderbook.update(&data);
-                assert_eq!(orderbook.verify_checksum(data.checksum), true);
+                assert!(orderbook.verify_checksum(data.checksum));
                 // println!("{:#?}", orderbook);
             }
             _ => panic!("Order book snapshot data expected."),
@@ -232,7 +232,7 @@ async fn order_book_checksum() {
         match ws.next().await.unwrap() {
             Some(Data::OrderbookData(data)) if data.action == OrderbookAction::Update => {
                 orderbook.update(&data);
-                assert_eq!(orderbook.verify_checksum(data.checksum), true);
+                assert!(orderbook.verify_checksum(data.checksum));
             }
             _ => panic!("Order book update data expected."),
         }

--- a/src/ws/tests.rs
+++ b/src/ws/tests.rs
@@ -27,6 +27,32 @@ async fn init_api() -> Rest {
 }
 
 #[tokio::test]
+async fn subscribe_unsubscribe() {
+    let mut ws = init_ws().await;
+
+    // Channels: BTC, ETH
+    ws.subscribe(vec![
+        Channel::Trades("BTC-PERP".to_owned()),
+        Channel::Trades("ETH-PERP".to_owned()),
+    ])
+    .await
+    .expect("Subscribe failed");
+
+    // Channels: BTC
+    ws.unsubscribe(vec![Channel::Trades("ETH-PERP".to_owned())])
+        .await
+        .expect("Unsubscribe failed");
+
+    // Channels: BTC, LTC
+    ws.subscribe(vec![Channel::Trades("LTC-PERP".to_owned())])
+        .await
+        .expect("Subscribe failed");
+
+    // Channels: None
+    ws.unsubscribe_all().await.expect("Unsubscribe all failed");
+}
+
+#[tokio::test]
 async fn trades() {
     let mut ws = init_ws().await;
 
@@ -39,9 +65,7 @@ async fn trades() {
         _ => panic!("Trade data expected."),
     }
 
-    ws.unsubscribe(vec![Channel::Trades("BTC-PERP".to_owned())])
-        .await
-        .expect("Unsubscribe failed.");
+    ws.unsubscribe_all().await.expect("Unsubscribe failed");
 }
 
 #[tokio::test]
@@ -108,9 +132,7 @@ async fn order_book_update() {
         }
     }
 
-    ws.unsubscribe(vec![Channel::Orderbook("BTC-PERP".to_owned())])
-        .await
-        .expect("Unsubscribe failed.");
+    ws.unsubscribe_all().await.expect("Unsubscribe failed");
 }
 
 #[tokio::test]
@@ -214,6 +236,8 @@ async fn order_book_checksum() {
             }
             _ => panic!("Order book update data expected."),
         }
+
+        ws.unsubscribe_all().await.expect("Unsubscribe failed");
     }
 }
 
@@ -247,4 +271,6 @@ async fn fills() {
         _ => panic!("Fill data expected."),
     }
     */
+
+    ws.unsubscribe_all().await.expect("Unsubscribe failed");
 }

--- a/src/ws/tests.rs
+++ b/src/ws/tests.rs
@@ -38,6 +38,10 @@ async fn trades() {
         Some(Data::Trade(..)) => {}
         _ => panic!("Trade data expected."),
     }
+
+    ws.unsubscribe(vec![Channel::Trades("BTC-PERP".to_owned())])
+        .await
+        .expect("Unsubscribe failed.");
 }
 
 #[tokio::test]
@@ -103,6 +107,10 @@ async fn order_book_update() {
             _ => panic!("Order book update data expected."),
         }
     }
+
+    ws.unsubscribe(vec![Channel::Orderbook("BTC-PERP".to_owned())])
+        .await
+        .expect("Unsubscribe failed.");
 }
 
 #[tokio::test]


### PR DESCRIPTION
- `Ws.unsubscribe(channels)` which allows users to selectively unsubscribe from Channels
- `Ws.unsubscribe_all()` which allows users to unsubscribe from all currently subscribed Channels

Although I don't think the average user would use this functionality, it is now also possible to subscribe, unsubscribe, then resubscribe to the same or different channels (instead of instantiating a new `Ws` object for new subscriptions). Since this is uncommon behavior I didn't bother to prevent data that is received during the unsubscribing process from being returned back to the user - doing so would negatively impact performance anyway, by requiring an additional check on all data that is returned from the websocket.