### PR TITLE
Implement order updates over websockets with tests

### DIFF
--- a/src/rest/mod.rs
+++ b/src/rest/mod.rs
@@ -3,7 +3,7 @@
 mod error;
 mod model;
 #[cfg(test)]
-pub mod tests;
+pub(crate) mod tests;
 
 pub use error::*;
 pub use model::*;

--- a/src/rest/mod.rs
+++ b/src/rest/mod.rs
@@ -3,7 +3,7 @@
 mod error;
 mod model;
 #[cfg(test)]
-mod tests;
+pub mod tests;
 
 pub use error::*;
 pub use model::*;

--- a/src/rest/model.rs
+++ b/src/rest/model.rs
@@ -329,6 +329,34 @@ pub enum OrderSide {
 
 #[derive(Copy, Clone, Debug, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
+/// Represents the status of the order.
+/// However, the REST and websockets APIs assign these values differently.
+///
+/// When submitting orders over REST, the API will immediately return whether
+/// the order is accepted into FTX's queue for processing, but not the results
+/// of the processing. If the order is accepted into the queue, the API will
+/// return an `OrderInfo` with `OrderStatus::New`, otherwise it will return an error.
+///
+/// If the order is rejected during processing (e.g. when submitting a post-only
+/// limit order with a price that would be executed as a taker order), the user
+/// will not know this unless they do one of the following:
+/// - Call the `get_order` REST API to see if the order status has been updated
+/// - Listen to orders over websockets to be notified of the update order status
+///   as soon as it is available.
+/// To get near-immediate feedback on the status of possibly-rejected orders,
+/// we recommend subscribing to the `Orders` channel over websockets.
+///
+/// When listening to orders over websockets, the websockets API will report
+/// only the status of the order when it has been processed:
+/// - If an order is rejected upon processing, the websockets API will emit an
+///   `OrderInfo` with `OrderStatus::Closed`. Unlike the REST API, it will not
+///   return an `OrderInfo` with `OrderStatus::New`.
+/// - If a limit order is accepted and not immediately filled upon processing,
+///   the websockets API will emit an `OrderInfo` with `OrderStatus::New`,
+///   confirming the order as active.
+/// - If a limit or market order is accepted and filled immediately upon
+///   processing, the websockets API emits an `OrderInfo` with
+///   `OrderStatus::Closed`.
 pub enum OrderStatus {
     /// Rest: accepted but not processed yet; Ws: processed and confirmed active
     New,

--- a/src/rest/model.rs
+++ b/src/rest/model.rs
@@ -330,9 +330,12 @@ pub enum OrderSide {
 #[derive(Copy, Clone, Debug, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub enum OrderStatus {
-    New, // accepted but not processed yet
+    /// Rest: accepted but not processed yet; Ws: processed and confirmed active
+    New,
+    /// Applicable to Rest only
     Open,
-    Closed, // filled or cancelled
+    /// Rest: filled or cancelled; Ws: filled, rejected, or cancelled
+    Closed,
 }
 
 #[derive(Clone, Debug, Deserialize)]

--- a/src/rest/tests.rs
+++ b/src/rest/tests.rs
@@ -284,20 +284,5 @@ pub async fn manipulate_orders() {
     assert_eq!(dec!(0), rejected_order.filled_size);
     assert_eq!(None, rejected_order.avg_fill_price);
 
-    // When submitting a post-only order that will be rejected, the REST response
-    // will report status as New - they are accepted but not processed.
-    // To get near-immediate feedback on the status of possibly-rejected orders,
-    // you must be subscribed to the orders channel over websockets.
-    //
-    // Note that when listening to orders over websockets, the websockets API
-    // will report only the status of the order after it has been processed:
-    // - If an order is rejected upon processing, the websockets API emits
-    //   status = Closed. Unlike the REST API, it will not return an order update
-    //   with status = New.
-    // - If a limit order is accepted and not immediately filled upon processing
-    //   the websockets API emits status = New, which confirms the order as
-    //   active.
-    // - If a limit or market order is accepted and filled immediately upon
-    //   processing, the websockets API emits status = Closed.
     assert_eq!(OrderStatus::New, rejected_order.status);
 }

--- a/src/ws/mod.rs
+++ b/src/ws/mod.rs
@@ -148,6 +148,7 @@ impl Ws {
                 Channel::Trades(symbol) => ("trades", symbol),
                 Channel::Ticker(symbol) => ("ticker", symbol),
                 Channel::Fills => ("fills", "".to_string()),
+                Channel::Orders => ("orders", "".to_string()),
             };
 
             self.stream
@@ -235,6 +236,8 @@ impl Ws {
                 }
                 ResponseData::Ticker(ticker) => {
                     self.buf.push_back(Data::Ticker(ticker));
+                ResponseData::Order(order) => {
+                    self.buf.push_back(Data::Order(order));
                 }
             }
         }

--- a/src/ws/mod.rs
+++ b/src/ws/mod.rs
@@ -236,6 +236,7 @@ impl Ws {
                 }
                 ResponseData::Ticker(ticker) => {
                     self.buf.push_back(Data::Ticker(ticker));
+                }
                 ResponseData::Order(order) => {
                     self.buf.push_back(Data::Order(order));
                 }

--- a/src/ws/model.rs
+++ b/src/ws/model.rs
@@ -1,4 +1,4 @@
-pub use crate::rest::{Coin, Id, MarketType, Side, Symbol};
+pub use crate::rest::{Coin, Id, MarketType, OrderInfo, Side, Symbol};
 use chrono::{DateTime, Utc};
 use crc32fast::Hasher;
 use rust_decimal::Decimal;
@@ -14,6 +14,7 @@ pub enum Channel {
     Trades(Symbol),
     Ticker(Symbol),
     Fills,
+    Orders,
 }
 
 /*
@@ -55,6 +56,7 @@ pub enum ResponseData {
     Trades(Vec<Trade>),
     OrderbookData(OrderbookData),
     Fill(Fill),
+    Order(OrderInfo),
 }
 
 /// Represents the data we return to the user
@@ -64,6 +66,7 @@ pub enum Data {
     Trade(Trade),
     OrderbookData(OrderbookData),
     Fill(Fill),
+    Order(OrderInfo),
 }
 
 #[serde_as]


### PR DESCRIPTION
Some notes:
- `OrderStatus` means different things depending on whether you're using `Rest` or `Ws`. I added some comments explaining these differences.
- I reused the functionality that was previously in `rest::place_modify_cancel_orders` as part of the tests for orders over websockets. I moved the body of that test into a separate function so that it could be called from `ws::tests::orders`, but that required making the `rest::tests` module public. A motivated library user could access the `rest::tests` module if they really wanted to for some reason, but they'd only have access to the benign `manipulate_orders` function which only sends and cancels orders that never get filled, and the `rest::tests` module doesn't even show up in the docs for regular users, I'm assuming because of the `#[cfg(test)` attribute on `mod tests`. So I think this is fine.