### PR TITLE
Added the functionality to have an unauthenticated websocket

### DIFF
--- a/examples/watch_market.rs
+++ b/examples/watch_market.rs
@@ -9,9 +9,11 @@ use std::io::Write;
 async fn main() -> Result<()> {
     dotenv().ok();
 
-    let mut websocket = Ws::connect(Some((var("API_KEY").expect("API Key is not defined."),
-        var("API_SECRET").expect("API Secret is not defined."))),
-
+    let mut websocket = Ws::connect(
+        Some((
+            var("API_KEY").expect("API Key is not defined."),
+            var("API_SECRET").expect("API Secret is not defined."),
+        )),
         var("SUBACCOUNT").ok(),
     )
     .await?;

--- a/examples/watch_market.rs
+++ b/examples/watch_market.rs
@@ -9,9 +9,9 @@ use std::io::Write;
 async fn main() -> Result<()> {
     dotenv().ok();
 
-    let mut websocket = Ws::connect(
-        var("API_KEY").expect("API Key is not defined."),
-        var("API_SECRET").expect("API Secret is not defined."),
+    let mut websocket = Ws::connect(Some((var("API_KEY").expect("API Key is not defined."),
+        var("API_SECRET").expect("API Secret is not defined."))),
+
         var("SUBACCOUNT").ok(),
     )
     .await?;

--- a/src/ws/error.rs
+++ b/src/ws/error.rs
@@ -9,6 +9,7 @@ pub enum Error {
     Serde(serde_json::Error),
     NotSubscribedToThisChannel(Channel),
     MissingSubscriptionConfirmation,
+    SocketNotAuthenticated,
 }
 
 impl From<tungstenite::Error> for Error {

--- a/src/ws/mod.rs
+++ b/src/ws/mod.rs
@@ -8,6 +8,7 @@ mod tests;
 pub use error::*;
 pub use model::*;
 
+use crate::ws::Channel::Fills;
 use futures_util::{SinkExt, StreamExt};
 use hmac_sha256::HMAC;
 use serde_json::json;
@@ -23,6 +24,8 @@ pub struct Ws {
     stream: WebSocketStream<MaybeTlsStream<TcpStream>>,
     buf: VecDeque<Data>,
     ping_timer: Interval,
+    /// Whether the websocket was opened authenticated with API keys or not
+    is_authenticated: bool,
 }
 
 impl Ws {
@@ -31,53 +34,59 @@ impl Ws {
 
     async fn connect_with_endpoint(
         endpoint: &str,
-        key: String,
-        secret: String,
+        key_secret: Option<(String, String)>,
         subaccount: Option<String>,
     ) -> Result<Self> {
         let (mut stream, _) = connect_async(endpoint).await?;
+        let is_authenticated = key_secret.is_some();
+        if let Some((key, secret)) = key_secret {
+            let timestamp = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_millis();
+            let sign_payload = format!("{}websocket_login", timestamp);
+            let sign = HMAC::mac(sign_payload.as_bytes(), secret.as_bytes());
+            let sign = hex::encode(sign);
 
-        let timestamp = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap()
-            .as_millis();
-        let sign_payload = format!("{}websocket_login", timestamp);
-        let sign = HMAC::mac(sign_payload.as_bytes(), secret.as_bytes());
-        let sign = hex::encode(sign);
-
-        stream
-            .send(Message::Text(
-                json!({
-                    "op": "login",
-                    "args": {
-                        "key": key,
-                        "sign": sign,
-                        "time": timestamp as u64,
-                        "subaccount": subaccount,
-                    }
-                })
-                .to_string(),
-            ))
-            .await?;
-
+            stream
+                .send(Message::Text(
+                    json!({
+                        "op": "login",
+                        "args": {
+                            "key": key,
+                            "sign": sign,
+                            "time": timestamp as u64,
+                            "subaccount": subaccount,
+                        }
+                    })
+                    .to_string(),
+                ))
+                .await?;
+        }
         Ok(Self {
             channels: Vec::new(),
             stream,
             buf: VecDeque::new(),
             ping_timer: time::interval(Duration::from_secs(15)),
+            is_authenticated,
         })
     }
-
-    pub async fn connect(key: String, secret: String, subaccount: Option<String>) -> Result<Self> {
-        Self::connect_with_endpoint(Self::ENDPOINT, key, secret, subaccount).await
-    }
-
-    pub async fn connect_us(
-        key: String,
-        secret: String,
+    pub async fn connect(
+        // Pair (API_KEY, SECRET_KEY) for authentification.
+        // The channels FILL, ORDER, and FTX Pay require authentification
+        key_secret: Option<(String, String)>,
         subaccount: Option<String>,
     ) -> Result<Self> {
-        Self::connect_with_endpoint(Self::ENDPOINT_US, key, secret, subaccount).await
+        Self::connect_with_endpoint(Self::ENDPOINT, key_secret, subaccount).await
+    }
+
+    // Pair (API_KEY, SECRET_KEY) for authentification.
+    // The channels FILL, ORDER, and FTX Pay require authentification
+    pub async fn connect_us(
+        key_secret: Option<(String, String)>,
+        subaccount: Option<String>,
+    ) -> Result<Self> {
+        Self::connect_with_endpoint(Self::ENDPOINT_US, key_secret, subaccount).await
     }
 
     async fn ping(&mut self) -> Result<()> {
@@ -94,8 +103,13 @@ impl Ws {
     }
 
     /// Subscribe to specified `Channel`s
+    /// For FILLS the socket needs to be authenticated
     pub async fn subscribe(&mut self, channels: Vec<Channel>) -> Result<()> {
         for channel in channels.iter() {
+            // Subscribing to fills requires us to be authenticated via an API key
+            if channel == &Fills && !self.is_authenticated {
+                return Err(Error::SocketNotAuthenticated);
+            }
             self.channels.push(channel.clone());
         }
 

--- a/src/ws/mod.rs
+++ b/src/ws/mod.rs
@@ -122,7 +122,7 @@ impl Ws {
     pub async fn unsubscribe(&mut self, channels: Vec<Channel>) -> Result<()> {
         // Check that the specified channels match an existing one
         for channel in channels.iter() {
-            if !self.channels.contains(&channel) {
+            if !self.channels.contains(channel) {
                 return Err(Error::NotSubscribedToThisChannel(channel.clone()));
             }
         }

--- a/src/ws/tests.rs
+++ b/src/ws/tests.rs
@@ -287,8 +287,7 @@ async fn subscribe_to_fill_on_unauthenticated_channel() {
     let mut ws = init_unauthenticated_ws().await;
     let result = ws.subscribe(vec![Channel::Fills]).await;
     if let Err(Error::SocketNotAuthenticated) = result {
-        return;
     } else {
-        assert!(false);
+        panic!("Should not be able to subscribe to FILL-updates on an unauthenticated websocket")
     }
 }


### PR DESCRIPTION
Background : 
- FTX websockets do not need be authenticated (i.e. signed into with an API key) for almost all of the market data. The only channels that require authentication are FILLS, ORDERS, and FTX PAY. 
- If the library is purely used to gather market data, it's desirable to not expose one's keys to it.
- New users will have an easier time testing the library if they don't need to provide their API keys to begin with.

Proposed changes:
- The connect() functions for the websocket take an Option((String,String)) to optionally provide an API/Secret key to make the websocket auhenticated (as is now the default). This breaks the existing signature of "connect".
- The WS Struct now has a variable to keep track of whether the socket is authenticated or not.
- Adjusted all tests to unauthenticated and authenticated sockets.
- Added a test for FILLS, that is expected to break for an unauthenticated socket.