### PR TITLE
implement stream for Ws

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ version = "0.3.1"
 chrono = {version = "^0.4.19", features = ["serde"]}
 crc32fast = "^1.2.1"
 dotenv = "^0.15.0"
-futures-util = {version = "^0.3.14", optional = true}
+futures = {version = "0.3", optional = true}
 hex = "^0.4.3"
 hmac-sha256 = "^0.1.7"
 log = "^0.4.14"
@@ -34,4 +34,4 @@ tokio = {version = "^1.5.0", features = ["full"]}
 
 [features]
 default = ["ws"]
-ws = ["tokio-tungstenite", "tokio", "futures-util"]
+ws = ["tokio-tungstenite", "tokio", "futures"]

--- a/examples/watch_market.rs
+++ b/examples/watch_market.rs
@@ -1,6 +1,7 @@
 use dotenv::dotenv;
 use ftx::ws::Result;
 use ftx::ws::{Channel, Data, Orderbook, Ws};
+use futures::stream::StreamExt;
 use std::env::var;
 use std::io;
 use std::io::Write;
@@ -29,7 +30,7 @@ async fn main() -> Result<()> {
         .await?;
 
     loop {
-        let data = websocket.next().await?.expect("No data received");
+        let data = websocket.next().await.expect("No data received")?;
 
         match data {
             Data::Trade(trade) => {

--- a/src/ws/tests.rs
+++ b/src/ws/tests.rs
@@ -66,7 +66,7 @@ async fn trades() {
         .expect("Subscription failed.");
 
     match ws.next().await.unwrap() {
-        Some(Data::Trade(..)) => {}
+        Ok(Data::Trade(..)) => {}
         _ => panic!("Trade data expected."),
     }
 
@@ -86,7 +86,7 @@ async fn order_book_update() {
 
     // The initial snapshot of the order book
     match ws.next().await.unwrap() {
-        Some(Data::OrderbookData(data)) if data.action == OrderbookAction::Partial => {
+        Ok(Data::OrderbookData(data)) if data.action == OrderbookAction::Partial => {
             orderbook.update(&data);
             assert!(orderbook.verify_checksum(data.checksum));
             // println!("{:#?}", orderbook);
@@ -97,7 +97,7 @@ async fn order_book_update() {
     // Update the order book 10 times
     for _i in 1..10 {
         match ws.next().await.unwrap() {
-            Some(Data::OrderbookData(data)) if data.action == OrderbookAction::Update => {
+            Ok(Data::OrderbookData(data)) if data.action == OrderbookAction::Update => {
                 // Check that removed orders are in the orderbook
                 for bid in &data.bids {
                     if bid.1 == dec!(0) {
@@ -225,7 +225,7 @@ async fn order_book_checksum() {
 
         // Initial snapshot
         match ws.next().await.unwrap() {
-            Some(Data::OrderbookData(data)) if data.action == OrderbookAction::Partial => {
+            Ok(Data::OrderbookData(data)) if data.action == OrderbookAction::Partial => {
                 orderbook.update(&data);
                 assert!(orderbook.verify_checksum(data.checksum));
                 // println!("{:#?}", orderbook);
@@ -235,7 +235,7 @@ async fn order_book_checksum() {
 
         // Orderbook update
         match ws.next().await.unwrap() {
-            Some(Data::OrderbookData(data)) if data.action == OrderbookAction::Update => {
+            Ok(Data::OrderbookData(data)) if data.action == OrderbookAction::Update => {
                 orderbook.update(&data);
                 assert!(orderbook.verify_checksum(data.checksum));
             }
@@ -314,7 +314,7 @@ async fn orders() {
 
     // Initial order placement
     let initial_order_placement = match ws.next().await.unwrap() {
-        Some(Data::Order(order)) => order,
+        Ok(Data::Order(order)) => order,
         _ => panic!("Order data expected."),
     };
     // println!("{:?}", initial_order_placement);
@@ -322,7 +322,7 @@ async fn orders() {
 
     // Initial order cancelled during modification
     let initial_order_cancellation = match ws.next().await.unwrap() {
-        Some(Data::Order(order)) => order,
+        Ok(Data::Order(order)) => order,
         _ => panic!("Order data expected."),
     };
     // println!("{:?}", initial_order_cancellation);
@@ -331,7 +331,7 @@ async fn orders() {
 
     // Modified order placement
     let modified_order_placement = match ws.next().await.unwrap() {
-        Some(Data::Order(order)) => order,
+        Ok(Data::Order(order)) => order,
         _ => panic!("Order data expected."),
     };
     // println!("{:?}", modified_order_placement);
@@ -340,7 +340,7 @@ async fn orders() {
 
     // Modified order explicit cancellation
     let modified_order_cancellation = match ws.next().await.unwrap() {
-        Some(Data::Order(order)) => order,
+        Ok(Data::Order(order)) => order,
         _ => panic!("Order data expected."),
     };
     // println!("{:?}", modified_order_cancellation);
@@ -349,7 +349,7 @@ async fn orders() {
 
     // Rejected order placement
     let rejected_order_placement = match ws.next().await.unwrap() {
-        Some(Data::Order(order)) => order,
+        Ok(Data::Order(order)) => order,
         _ => panic!("Order data expected."),
     };
     // println!("{:?}", rejected_order_placement);


### PR DESCRIPTION
Originally Ws has a customized `next` function instead of using the Stream protocol, which forbids applying stream combinators on it (e.g. ready_chunks for batch receive). This PR implement the `futures::Stream` trait for Ws.

This is a BREAKING CHANGE