### PR TITLE
start_time and end_time requires Unix timestamp

### DIFF
--- a/src/rest/mod.rs
+++ b/src/rest/mod.rs
@@ -357,10 +357,10 @@ impl Rest {
             params.push(format!("limit={}", limit));
         }
         if let Some(start_time) = start_time {
-            params.push(format!("start_time={}", start_time));
+            params.push(format!("start_time={}", start_time.timestamp()));
         }
         if let Some(end_time) = end_time {
-            params.push(format!("end_time={}", end_time));
+            params.push(format!("end_time={}", end_time.timestamp()));
         }
 
         self.get(
@@ -393,10 +393,10 @@ impl Rest {
             params.push(format!("limit={}", limit));
         }
         if let Some(start_time) = start_time {
-            params.push(format!("start_time={}", start_time));
+            params.push(format!("start_time={}", start_time.timestamp()));
         }
         if let Some(end_time) = end_time {
-            params.push(format!("end_time={}", end_time));
+            params.push(format!("end_time={}", end_time.timestamp()));
         }
 
         self.get(


### PR DESCRIPTION
Background:
Noticed that the time bounds arguments to some queries were not returning the correct values. They expect a Unix time stamp which was not being provided before. Using the .timestamp() function solves this.

Changed:
* Timestamps use .timestamp() function for transaction date bounds