### PR TITLE
Add github as dependancy example in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,10 @@ Add the following line to your Cargo.toml file:
 ```
 ftx = "0.3.1"
 ```
+Or for the latest github (nightly) version:
+```
+ftx = { git = "https://github.com/fabianboesiger/ftx", branch = "main" }
+```
 
 ## Usage
 


### PR DESCRIPTION
The current cargo version is not working at all so this is useful for people who had my issue when I first used this module.
If the cargo version becomes working again, it is still useful to include the import example because if people want to test the nightly version then it is straightforward.