### PR TITLE
Fixed bug in Orderbook struct

### DIFF
--- a/src/ws/model.rs
+++ b/src/ws/model.rs
@@ -141,6 +141,8 @@ impl Orderbook {
     pub fn update(&mut self, data: &OrderbookData) {
         match data.action {
             OrderbookAction::Partial => {
+                self.bids.clear();
+                self.asks.clear();
                 for bid in &data.bids {
                     self.bids.insert(bid.0, bid.1);
                 }

--- a/src/ws/tests.rs
+++ b/src/ws/tests.rs
@@ -110,7 +110,7 @@ async fn order_book_update() {
                 // Check that inserted orders have been updated correctly
                 for bid in &data.bids {
                     if bid.1 == dec!(0) {
-                        assert!(orderbook.bids.contains_key(&bid.0));
+                        assert!(!orderbook.bids.contains_key(&bid.0));
                     } else {
                         assert_eq!(orderbook.bids.get(&bid.0), Some(&bid.1));
                     }


### PR DESCRIPTION
Background:
The Orderbook struct keeps track of the checksums provided for correctness. When a new snapshot is provided the structure should delete everything it has known before about the order book. 

Changes:
- Delete old data in order book when a snapshot is provided
- Fixed a small bug in one of the order book tests