### PR TITLE
Addition of trigger orders

### DIFF
--- a/src/rest/mod.rs
+++ b/src/rest/mod.rs
@@ -1,7 +1,7 @@
 //! This module is used to interact with the REST API.
 
 mod error;
-pub mod model;
+mod model;
 #[cfg(test)]
 pub(crate) mod tests;
 

--- a/src/rest/mod.rs
+++ b/src/rest/mod.rs
@@ -453,6 +453,36 @@ impl Rest {
         .await
     }
 
+    #[allow(clippy::too_many_arguments)]
+    pub async fn place_trigger_order(
+        &self,
+        market: &str,
+        side: Side,
+        size: Decimal,
+        r#type: OrderType,
+        reduce_only: Option<bool>,
+        retry_until_filled: Option<bool>,
+        trigger_price: Option<Decimal>,
+        order_price: Option<Decimal>,
+        trail_value: Option<Decimal>,
+    ) -> Result<OrderInfo> {
+        self.post(
+            "/conditional_orders",
+            Some(json!({
+                "market": market,
+                "side": side,
+                "size": size,
+                "type": r#type,
+                "reduceOnly": reduce_only.unwrap_or(false),
+                "retryUntilFilled": retry_until_filled.unwrap_or(true),
+                "triggerPrice": trigger_price,
+                "orderPrice": order_price,
+                "trailValue": trail_value,
+            })),
+        )
+        .await
+    }
+
     pub async fn modify_order(
         &self,
         order_id: Id,

--- a/src/rest/mod.rs
+++ b/src/rest/mod.rs
@@ -1,7 +1,7 @@
 //! This module is used to interact with the REST API.
 
 mod error;
-mod model;
+pub mod model;
 #[cfg(test)]
 pub(crate) mod tests;
 
@@ -460,9 +460,9 @@ impl Rest {
         side: Side,
         size: Decimal,
         r#type: OrderType,
+        trigger_price: Decimal,
         reduce_only: Option<bool>,
         retry_until_filled: Option<bool>,
-        trigger_price: Option<Decimal>,
         order_price: Option<Decimal>,
         trail_value: Option<Decimal>,
     ) -> Result<OrderInfo> {

--- a/src/rest/model.rs
+++ b/src/rest/model.rs
@@ -408,11 +408,11 @@ pub struct OrderInfo {
     pub price: Option<Decimal>, // null for new market orders
     pub size: Decimal,
     pub reduce_only: Option<bool>,
-    pub ioc: bool,
-    pub post_only: bool,
+    pub ioc: Option<bool>,
+    pub post_only: Option<bool>,
     pub status: OrderStatus,
-    pub filled_size: Decimal,
-    pub remaining_size: Decimal,
+    pub filled_size: Option<Decimal>,
+    pub remaining_size: Option<Decimal>,
     pub avg_fill_price: Option<Decimal>,
     pub liquidation: Option<bool>,
     pub created_at: DateTime<Utc>,
@@ -421,5 +421,6 @@ pub struct OrderInfo {
     pub retry_until_filled: Option<bool>,
     pub trigger_price: Option<Decimal>,
     pub order_price: Option<Decimal>,
-    pub trail_value: Option<Decimal>,
+    pub triggered_at: Option<String>,
+    pub error: Option<String>,
 }

--- a/src/rest/model.rs
+++ b/src/rest/model.rs
@@ -353,6 +353,9 @@ pub struct WalletDeposit {
 pub enum OrderType {
     Market,
     Limit,
+    Stop,
+    TrailingStop,
+    TakeProfit
 }
 
 #[derive(Copy, Clone, Debug, Deserialize, PartialEq)]
@@ -404,7 +407,7 @@ pub struct OrderInfo {
     pub side: Side,
     pub price: Option<Decimal>, // null for new market orders
     pub size: Decimal,
-    pub reduce_only: bool,
+    pub reduce_only: Option<bool>,
     pub ioc: bool,
     pub post_only: bool,
     pub status: OrderStatus,
@@ -414,4 +417,9 @@ pub struct OrderInfo {
     pub liquidation: Option<bool>,
     pub created_at: DateTime<Utc>,
     pub client_id: Option<String>,
+    pub order_type: String,
+    pub retry_until_filled: Option<bool>,
+    pub trigger_price: Option<Decimal>,
+    pub order_price: Option<Decimal>,
+    pub trail_value: Option<Decimal>,
 }

--- a/src/rest/model.rs
+++ b/src/rest/model.rs
@@ -355,7 +355,7 @@ pub enum OrderType {
     Limit,
     Stop,
     TrailingStop,
-    TakeProfit
+    TakeProfit,
 }
 
 #[derive(Copy, Clone, Debug, Deserialize, PartialEq)]

--- a/src/rest/tests.rs
+++ b/src/rest/tests.rs
@@ -262,7 +262,7 @@ pub async fn manipulate_orders() {
     let cancelled_order = api.get_order(modified_order.id).await.unwrap();
     // println!("Cancelled order: {:?}", cancelled_order);
     assert_eq!(modified_order.id, cancelled_order.id);
-    assert_eq!(dec!(0), cancelled_order.filled_size);
+    assert_eq!(dec!(0), cancelled_order.filled_size?);
     assert_eq!(None, cancelled_order.avg_fill_price);
     assert_eq!(OrderStatus::Closed, cancelled_order.status);
 
@@ -282,7 +282,7 @@ pub async fn manipulate_orders() {
         )
         .await
         .unwrap();
-    assert_eq!(dec!(0), rejected_order.filled_size);
+    assert_eq!(dec!(0), rejected_order.filled_size?);
     assert_eq!(None, rejected_order.avg_fill_price);
 
     assert_eq!(OrderStatus::New, rejected_order.status);

--- a/src/rest/tests.rs
+++ b/src/rest/tests.rs
@@ -262,7 +262,7 @@ pub async fn manipulate_orders() {
     let cancelled_order = api.get_order(modified_order.id).await.unwrap();
     // println!("Cancelled order: {:?}", cancelled_order);
     assert_eq!(modified_order.id, cancelled_order.id);
-    assert_eq!(dec!(0), cancelled_order.filled_size?);
+    assert_eq!(dec!(0), cancelled_order.filled_size.unwrap());
     assert_eq!(None, cancelled_order.avg_fill_price);
     assert_eq!(OrderStatus::Closed, cancelled_order.status);
 
@@ -282,7 +282,7 @@ pub async fn manipulate_orders() {
         )
         .await
         .unwrap();
-    assert_eq!(dec!(0), rejected_order.filled_size?);
+    assert_eq!(dec!(0), rejected_order.filled_size.unwrap());
     assert_eq!(None, rejected_order.avg_fill_price);
 
     assert_eq!(OrderStatus::New, rejected_order.status);


### PR DESCRIPTION
This is a PR to add trigger orders.
I will let you know when I have tested this addition myself.

This is currently a draft because it is not ready yet and I may have made some mistakes.
Any feedback would be appreciated.

Breaking changes:

reduce_only,
ioc,
post_only,
filled_size,
remaining_size

are now all Option types