### PR TITLE
Remove field `order_type`

### DIFF
--- a/src/rest/model.rs
+++ b/src/rest/model.rs
@@ -417,7 +417,6 @@ pub struct OrderInfo {
     pub liquidation: Option<bool>,
     pub created_at: DateTime<Utc>,
     pub client_id: Option<String>,
-    pub order_type: String,
     pub retry_until_filled: Option<bool>,
     pub trigger_price: Option<Decimal>,
     pub order_price: Option<Decimal>,


### PR DESCRIPTION
For `OrderInfo` There is no field called `order_type` in the response, it is instead called `type`.