### PR TITLE
Fix GET /orders/by_client_id response type

### DIFF
--- a/src/rest/model/orders.rs
+++ b/src/rest/model/orders.rs
@@ -235,7 +235,7 @@ impl Request for GetOrderByClientId {
     const PATH: &'static str = "/orders/by_client_id/{}";
     const AUTH: bool = true;
 
-    type Response = String;
+    type Response = OrderInfo;
 
     fn path(&self) -> Cow<'_, str> {
         Cow::Owned(format!("/orders/by_client_id/{}", self.client_id))


### PR DESCRIPTION
Per official API document, the response from `/orders/by_client_id/...` must be the same with `/orders/...` and `/orders/.../modify` .