### PR TITLE
Fixed field types for FutureStats requests 

### DIFF
--- a/src/rest/model/futures.rs
+++ b/src/rest/model/futures.rs
@@ -102,11 +102,11 @@ impl Request for GetFundingRates {
 #[serde(rename_all = "camelCase")]
 pub struct FutureStats {
     pub volume: Decimal,
-    pub next_funding_rate: Decimal,
-    pub next_funding_time: DateTime<Utc>,
-    pub expiration_price: Decimal,
-    pub predicted_expiration_price: Decimal,
-    pub strike_price: Decimal,
+    pub next_funding_rate: Option<Decimal>,
+    pub next_funding_time: Option<DateTime<Utc>>,
+    pub expiration_price: Option<Decimal>,
+    pub predicted_expiration_price: Option<Decimal>,
+    pub strike_price: Option<Decimal>,
     pub open_interest: Decimal,
 }
 


### PR DESCRIPTION
Accounts for the fields that are only applicable under certain futures types.

- nextFundingRate and nextFundingTime only applicable for perpetual contracts
- expirationPrice only applicable if the future has expired
- predictedExpirationPrice only applicable if the future has not expired
- strikePrice only applicable for MOVE contracts

volume and openInterest are always present.