### PR TITLE
Make Rest client clonable

### DIFF
--- a/src/rest/mod.rs
+++ b/src/rest/mod.rs
@@ -24,7 +24,7 @@ macro_rules! deprecate_msg {
         "This function is deprecated. Please use Rest::request instead."
     };
 }
-
+#[derive(Debug, Clone)]
 pub struct Rest {
     secret: Option<String>,
     client: Client,


### PR DESCRIPTION
The Rest client is more or less a wrapper around the reqwest client which is by design clonable (the inner workings of the reqwest client are wrapped in an Arc). Therefore, the Rest client should inherit cloning. Otherwise, users of the Rest client need to wrap the client in another Arc to make it clonable.