### PR TITLE
Missing resolutions + Trade struct consistency

### DIFF
--- a/src/rest/model/common.rs
+++ b/src/rest/model/common.rs
@@ -137,7 +137,10 @@ pub enum WithdrawStatus {
 pub enum Resolution {
     FifteenSeconds,
     Minute,
+    FiveMinutes,
+    FifteenMinutes,
     Hour,
+    FourHours,
     Day,
     TwoDays,
     ThreeDays,
@@ -175,7 +178,10 @@ impl Resolution {
         match self {
             Resolution::FifteenSeconds => 15,
             Resolution::Minute => 60,
+            Resolution::FiveMinutes => 300,
+            Resolution::FifteenMinutes => 900,
             Resolution::Hour => 3600,
+            Resolution::FourHours => 14400,
             Resolution::Day => 86400,
             Resolution::TwoDays => 86400 * 2,
             Resolution::ThreeDays => 86400 * 3,

--- a/src/ws/model.rs
+++ b/src/ws/model.rs
@@ -82,16 +82,17 @@ pub struct Ticker {
     pub time: DateTime<Utc>,
 }
 
-#[derive(Copy, Clone, Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct Trade {
-    pub id: Id,
-    pub price: Decimal,
-    pub size: Decimal,
-    pub side: Side,
-    pub liquidation: bool,
-    pub time: DateTime<Utc>, // API returns "2021-05-23T05:24:24.315884+00:00"
-}
+// #[derive(Copy, Clone, Debug, Deserialize)]
+// #[serde(rename_all = "camelCase")]
+// pub struct Trade {
+//     pub id: Id,
+//     pub price: Decimal,
+//     pub size: Decimal,
+//     pub side: Side,
+//     pub liquidation: bool,
+//     pub time: DateTime<Utc>, // API returns "2021-05-23T05:24:24.315884+00:00"
+// }
+use crate::rest::Trade;
 
 /// Order book data received from FTX which is used for initializing and updating
 /// the OrderBook struct


### PR DESCRIPTION
Unless there is a reason seperate trade structs are use i think the same ones should be used