### PR TITLE
Exclude the id field from the wallet withdrawal method for now

### DIFF
--- a/src/rest/model/wallet.rs
+++ b/src/rest/model/wallet.rs
@@ -156,7 +156,9 @@ impl Request for GetCoins {
 #[derive(Clone, Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct WalletWithdrawal {
-    pub id: Id,
+    // Exclude `id` for now.  For FTX Card withdrawals `id` is unfortunately returned as an
+    // alphanumeric `String` (eg. `"swipe_170108"`) instead of a number.
+    /*pub id: Id,*/
     pub coin: String,
     pub size: Decimal,
     pub time: String,


### PR DESCRIPTION
This is a little hacky but unfortunately FTX decided to return a String instead of a Number for some withdrawal types (FTX card), and serde_json can't handle a mixed typed field like this out of the box. A custom type could be written but that's a bit more effort than what I'm hoping to invest in this issue at the moment. So in the meantime, excluding the `id` field entirely at least allows for the rest of the wallet withdrawal information to be returned once your account withdrawal history is polluted with an FTX card withdrawal