### PR TITLE
fixes on `/fills` endpoint

### DIFF
--- a/src/rest/model/common.rs
+++ b/src/rest/model/common.rs
@@ -5,7 +5,7 @@ pub type Id = u64;
 pub type Coin = String;
 pub type Symbol = String;
 
-#[derive(Copy, Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Copy, Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub enum OrderType {
     Market,
@@ -23,7 +23,7 @@ impl Default for OrderType {
     }
 }
 
-#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq)]
+#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 /// Represents the status of the order.
 /// However, the REST and websockets APIs assign these values differently.
@@ -62,7 +62,7 @@ pub enum OrderStatus {
     Closed,
 }
 
-#[derive(Copy, Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Copy, Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub enum Side {
     Buy,
@@ -75,7 +75,7 @@ impl Default for Side {
     }
 }
 
-#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq)]
+#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub enum FutureType {
     Future,
@@ -84,7 +84,7 @@ pub enum FutureType {
     Move,
 }
 
-#[derive(Copy, Clone, Debug, Deserialize, PartialEq)]
+#[derive(Copy, Clone, Debug, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub enum DepositStatus {
     Confirmed,
@@ -94,7 +94,7 @@ pub enum DepositStatus {
     Initiated,
 }
 
-#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq)]
+#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub enum MarketType {
     Future,
@@ -124,7 +124,7 @@ pub struct Position {
     pub collateral_used: Decimal,
 }
 
-#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq)]
+#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub enum WithdrawStatus {
     Requested,

--- a/src/rest/model/fills.rs
+++ b/src/rest/model/fills.rs
@@ -7,7 +7,7 @@ use serde::Serialize;
 #[derive(Debug, Clone, Serialize, Default)]
 
 pub struct GetFills<'a> {
-    #[serde(rename = "marketName")]
+    #[serde(rename = "market")]
     pub market_name: &'a str,
     #[serde(
         skip_serializing_if = "Option::is_none",

--- a/src/ws/model.rs
+++ b/src/ws/model.rs
@@ -268,7 +268,7 @@ impl Orderbook {
 #[serde(rename_all = "camelCase")]
 pub struct Fill {
     pub id: Id,
-    pub market: Symbol,
+    pub market: Option<Symbol>,
     pub future: Option<Symbol>,
     pub base_currency: Option<Coin>,
     pub quote_currency: Option<Coin>,
@@ -276,8 +276,8 @@ pub struct Fill {
     pub side: Side,
     pub price: Decimal,
     pub size: Decimal,
-    pub order_id: Id,
-    pub trade_id: Id,
+    pub order_id: Option<Id>,
+    pub trade_id: Option<Id>,
     pub time: DateTime<Utc>,
     pub fee: Decimal,
     pub fee_rate: Decimal,

--- a/src/ws/model.rs
+++ b/src/ws/model.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 use serde_with::{serde_as, TimestampSecondsWithFrac};
 use std::{collections::BTreeMap, ops::Not};
 
-#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub enum Channel {
     Orderbook(Symbol),
@@ -91,7 +91,7 @@ pub struct OrderbookData {
 
 type Checksum = u32;
 
-#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq)]
+#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub enum OrderbookAction {
     /// Initial snapshot of the orderbook
@@ -285,7 +285,7 @@ pub struct Fill {
     pub liquidity: Liquidity,
 }
 
-#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq)]
+#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub enum Liquidity {
     Maker,


### PR DESCRIPTION
fills can have null `market`, `order_id` and `trade_id` (see example - happens when you use Convert)

```
{
	"success": true,
	"result": [{
		"id": 9592640035,
		"market": null,
		"future": null,
		"baseCurrency": "FTT",
		"quoteCurrency": "USD",
		"type": "otc",
		"side": "buy",
		"price": 30.7952314,
		"size": 25.97804801,
		"orderId": null,
		"time": "2022-08-17T12:27:19.206419+00:00",
		"tradeId": null,
		"feeRate": 0.0,
		"fee": 0.0,
		"feeCurrency": "USD",
		"liquidity": "taker"
	}]
}
```

also, fix the market filter on `GetFills` - it's just `market` not `marketName`