### PR TITLE
feat: ensure orderbook is initialized with partial before accepting updates, verify checksums

### DIFF
--- a/examples/watch_market.rs
+++ b/examples/watch_market.rs
@@ -33,7 +33,7 @@ async fn main() -> Result<()> {
                 );
             }
             (_, Data::OrderbookData(orderbook_data)) => {
-                orderbook.update(&orderbook_data);
+                orderbook.update(&orderbook_data)?;
                 print!("."); // To signify orderbook update
                 io::stdout().flush().unwrap(); // Emits the output immediately
             }

--- a/src/ws/error.rs
+++ b/src/ws/error.rs
@@ -6,6 +6,12 @@ pub type Result<T> = std::result::Result<T, Error>;
 
 #[derive(Debug, Error)]
 pub enum Error {
+    #[error("Orderbook checksum was not correct")]
+    IncorrectChecksum,
+
+    #[error("Orderbook has not yet received partial")]
+    MissingPartial,
+
     #[error("Not subscribed to this channel {0:?}")]
     NotSubscribedToThisChannel(Channel),
 

--- a/src/ws/model.rs
+++ b/src/ws/model.rs
@@ -112,6 +112,22 @@ pub struct Orderbook {
     pub bids: BTreeMap<Decimal, Decimal>,
     pub asks: BTreeMap<Decimal, Decimal>,
 }
+
+fn format_value(value: &Decimal) -> String {
+    if value.fract().is_zero() {
+        format!("{value:.1}")
+    } else if *value < dec!(0.0001) {
+        let mut formatted = format!("{value:e}");
+        let minus_idx = formatted
+            .find('-')
+            .expect("Passed abs(value) higher than 1");
+        formatted.insert(minus_idx + 1, '0');
+        formatted
+    } else {
+        value.to_string()
+    }
+}
+
 impl Orderbook {
     pub fn new(symbol: Symbol) -> Orderbook {
         Orderbook {
@@ -133,7 +149,7 @@ impl Orderbook {
         self.bids.retain(|_k, v| v.is_zero().not());
         self.asks.retain(|_k, v| v.is_zero().not());
 
-        if self.verify_checksum(data.checksum) {
+        if self.verify_checksum(&data.checksum) {
             Ok(())
         } else {
             Err(Error::IncorrectChecksum)
@@ -151,60 +167,18 @@ impl Orderbook {
         }
     }
 
-    pub fn verify_checksum(&self, checksum: Checksum) -> bool {
-        /// padding a 0 if the Decimal is a whole number
-        fn _needs_padding(value: &Decimal) -> bool {
-            value.fract().is_zero()
-        }
-
+    pub fn verify_checksum(&self, checksum: &Checksum) -> bool {
         let input = (0..100)
             .into_iter()
             .zip(self.bids.iter().rev().zip(self.asks.iter()))
             .map(|(_, ((b_p, b_s), (a_p, a_s)))| {
-                // There may be a cleaner way to do this, but this avoids building more `String`s than necessary
-                match (
-                    _needs_padding(b_p),
-                    _needs_padding(b_s),
-                    _needs_padding(a_p),
-                    _needs_padding(a_s),
-                ) {
-                    (true, true, true, true) => {
-                        format!("{:.1}:{:.1}:{:.1}:{:.1}", b_p, b_s, a_p, a_s)
-                    }
-                    (true, true, true, false) => {
-                        format!("{:.1}:{:.1}:{:.1}:{}", b_p, b_s, a_p, a_s)
-                    }
-                    (true, true, false, true) => {
-                        format!("{:.1}:{:.1}:{}:{:.1}", b_p, b_s, a_p, a_s)
-                    }
-                    (true, true, false, false) => format!("{:.1}:{:.1}:{}:{}", b_p, b_s, a_p, a_s),
-                    (true, false, true, true) => {
-                        format!("{:.1}:{}:{:.1}:{:.1}", b_p, b_s, a_p, a_s)
-                    }
-                    (true, false, true, false) => format!("{:.1}:{}:{:.1}:{}", b_p, b_s, a_p, a_s),
-                    (true, false, false, true) => format!("{:.1}:{}:{}:{:.1}", b_p, b_s, a_p, a_s),
-                    (true, false, false, false) => {
-                        format!("{:.1}:{}:{}:{}", b_p, b_s, a_p, a_s)
-                    }
-                    (false, true, true, true) => {
-                        format!("{}:{:.1}:{:.1}:{:.1}", b_p, b_s, a_p, a_s)
-                    }
-                    (false, true, true, false) => format!("{}:{:.1}:{:.1}:{}", b_p, b_s, a_p, a_s),
-                    (false, true, false, true) => format!("{}:{:.1}:{}:{:.1}", b_p, b_s, a_p, a_s),
-                    (false, true, false, false) => {
-                        format!("{}:{:.1}:{}:{}", b_p, b_s, a_p, a_s)
-                    }
-                    (false, false, true, true) => format!("{}:{}:{:.1}:{:.1}", b_p, b_s, a_p, a_s),
-                    (false, false, true, false) => {
-                        format!("{}:{}:{:.1}:{}", b_p, b_s, a_p, a_s)
-                    }
-                    (false, false, false, true) => {
-                        format!("{}:{}:{}:{:.1}", b_p, b_s, a_p, a_s)
-                    }
-                    (false, false, false, false) => {
-                        format!("{}:{}:{}:{}", b_p, b_s, a_p, a_s)
-                    }
-                }
+                vec![
+                    format_value(b_p),
+                    format_value(b_s),
+                    format_value(a_p),
+                    format_value(a_s),
+                ]
+                .join(":")
             })
             .collect::<Vec<String>>()
             .join(":");
@@ -216,7 +190,7 @@ impl Orderbook {
         let output = hasher.finalize();
 
         // println!("Output: {}, Checksum: {}", output, checksum);
-        output == checksum
+        output == *checksum
     }
 
     /// Returns the price of the best bid
@@ -315,4 +289,16 @@ pub struct Fill {
 pub enum Liquidity {
     Maker,
     Taker,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // check examples from https://docs.ftx.com/#orderbooks
+    #[test]
+    fn test_format_value() {
+        assert_eq!(&format_value(&dec!(0.000075)), "7.5e-05");
+        assert_eq!(&format_value(&dec!(0.1)), "0.1");
+    }
 }

--- a/src/ws/tests.rs
+++ b/src/ws/tests.rs
@@ -79,9 +79,7 @@ async fn order_book_update() {
     // The initial snapshot of the order book
     match ws.next().await.unwrap() {
         Ok((_, Data::OrderbookData(data))) if data.action == OrderbookAction::Partial => {
-            orderbook.update(&data);
-            assert!(orderbook.verify_checksum(data.checksum));
-            // println!("{:#?}", orderbook);
+            assert!(orderbook.update(&data).is_ok());
         }
         _ => panic!("Order book snapshot data expected."),
     }
@@ -103,8 +101,7 @@ async fn order_book_update() {
                 }
 
                 // Update the order book
-                orderbook.update(&data);
-                assert!(orderbook.verify_checksum(data.checksum));
+                assert!(orderbook.update(&data).is_ok());
 
                 // Check that removed orders are no longer in the orderbook
                 // Check that inserted orders have been updated correctly
@@ -218,8 +215,7 @@ async fn order_book_checksum() {
         // Initial snapshot
         match ws.next().await.unwrap() {
             Ok((_, Data::OrderbookData(data))) if data.action == OrderbookAction::Partial => {
-                orderbook.update(&data);
-                assert!(orderbook.verify_checksum(data.checksum));
+                assert!(orderbook.update(&data).is_ok());
                 // println!("{:#?}", orderbook);
             }
             _ => panic!("Order book snapshot data expected."),
@@ -228,8 +224,7 @@ async fn order_book_checksum() {
         // Orderbook update
         match ws.next().await.unwrap() {
             Ok((_, Data::OrderbookData(data))) if data.action == OrderbookAction::Update => {
-                orderbook.update(&data);
-                assert!(orderbook.verify_checksum(data.checksum));
+                assert!(orderbook.update(&data).is_ok());
             }
             _ => panic!("Order book update data expected."),
         }

--- a/src/ws/tests.rs
+++ b/src/ws/tests.rs
@@ -69,7 +69,7 @@ async fn trades() {
 async fn order_book_update() {
     let mut ws = init_unauthenticated_ws().await;
 
-    let symbol: Symbol = String::from("BTC-PERP");
+    let symbol: Symbol = String::from("SHIB-PERP");
     ws.subscribe(&[Channel::Orderbook(symbol.to_owned())])
         .await
         .expect("Subscription failed.");


### PR DESCRIPTION
after running streaming orderbooks for several hours i have noticed i can get 'stuck' orders that are never removed. i guess this is because some update has been dropped. the checksum should be able to detect this but we aren't verifying it (i guess due to #120)