### PR TITLE
Permit the Get Lending Rates `previous` response field to be null

### DIFF
--- a/src/rest/model/spot_margin.rs
+++ b/src/rest/model/spot_margin.rs
@@ -14,7 +14,7 @@ pub struct GetLendingRates {}
 pub struct LendingRate {
     pub coin: String,
     pub estimate: Decimal, // estimated hourly lending rate for the next spot margin cycle
-    pub previous: Decimal, // hourly lending rate in the previous spot margin cycle
+    pub previous: Option<Decimal>, // hourly lending rate in the previous spot margin cycle
 }
 
 impl Request for GetLendingRates {


### PR DESCRIPTION
https://docs.ftx.com/#get-lending-rates currently claims that `previous` will always be a number, but it has been observed to be `null` in practice