### PR TITLE
Fixes: RUSTSEC-2021-0141 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ crc32fast = "^1.2.1"
 dotenvy = "0.15.5"
 futures = { version = "0.3", optional = true }
 hex = "^0.4.3"
-hmac-sha256 = "^0.1.7"
+hmac-sha256 = "1.1.4"
 http = "0.2"
 log = "^0.4.14"
 reqwest = { version = "^0.11.3", features = ["json"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ rust_decimal_macros = "^1.14.1"
 serde = { version = "^1.0.125", features = ["derive"] }
 serde_json = "^1.0.64"
 serde_qs = "0.10.1"
-serde_with = { version = "^1.9.1", features = ["chrono"] }
+serde_with = { version = "2.0.1", features = ["chrono"] }
 thiserror = "1"
 tokio = { version = "^1.5.0", features = ["macros"], optional = true }
 tokio-tungstenite = { version = "^0.14.0", features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ boolinator = "2.4"
 chrono = { version = "^0.4.19", features = ["serde"] }
 const_format = "0.2"
 crc32fast = "^1.2.1"
-dotenv = "^0.15.0"
+dotenvy = "0.15.5"
 futures = { version = "0.3", optional = true }
 hex = "^0.4.3"
 hmac-sha256 = "^0.1.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ rust_decimal = "^1.13.0"
 rust_decimal_macros = "^1.14.1"
 serde = { version = "^1.0.125", features = ["derive"] }
 serde_json = "^1.0.64"
-serde_qs = "0.8"
+serde_qs = "0.10.1"
 serde_with = { version = "^1.9.1", features = ["chrono"] }
 thiserror = "1"
 tokio = { version = "^1.5.0", features = ["macros"], optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ serde_qs = "0.10.1"
 serde_with = { version = "2.0.1", features = ["chrono"] }
 thiserror = "1"
 tokio = { version = "^1.5.0", features = ["macros"], optional = true }
-tokio-tungstenite = { version = "^0.14.0", features = [
+tokio-tungstenite = { version = "^0.17.2", features = [
     "native-tls",
 ], optional = true }
 

--- a/examples/btc_price.rs
+++ b/examples/btc_price.rs
@@ -1,4 +1,4 @@
-use dotenv::dotenv;
+use dotenvy::dotenv;
 use ftx::{
     options::Options,
     rest::{GetMarket, Rest, Result},

--- a/examples/get_account.rs
+++ b/examples/get_account.rs
@@ -1,4 +1,4 @@
-use dotenv::dotenv;
+use dotenvy::dotenv;
 use ftx::{
     options::Options,
     rest::{GetAccount, GetPositions, Rest},

--- a/examples/lending.rs
+++ b/examples/lending.rs
@@ -1,5 +1,5 @@
 use {
-    dotenv::dotenv,
+    dotenvy::dotenv,
     ftx::{
         options::Options,
         rest::{

--- a/examples/list_markets.rs
+++ b/examples/list_markets.rs
@@ -1,4 +1,4 @@
-use dotenv::dotenv;
+use dotenvy::dotenv;
 use ftx::{
     options::Options,
     rest::{GetMarkets, Rest, Result},

--- a/examples/watch_market.rs
+++ b/examples/watch_market.rs
@@ -1,4 +1,4 @@
-use dotenv::dotenv;
+use dotenvy::dotenv;
 use ftx::options::Options;
 use ftx::ws::Result;
 use ftx::ws::{Channel, Data, Orderbook, Ws};

--- a/src/rest/tests.rs
+++ b/src/rest/tests.rs
@@ -1,5 +1,5 @@
 use super::*;
-use dotenv::dotenv;
+use dotenvy::dotenv;
 use rust_decimal_macros::dec;
 use std::env::var;
 

--- a/src/ws/tests.rs
+++ b/src/ws/tests.rs
@@ -1,6 +1,6 @@
 use super::*;
 use crate::rest::{OrderStatus, Rest};
-use dotenv::dotenv;
+use dotenvy::dotenv;
 use rust_decimal_macros::dec;
 
 async fn init_authenticated_ws() -> Ws {


### PR DESCRIPTION
Fixes: RUSTSEC-2021-0141
https://rustsec.org/advisories/RUSTSEC-2021-0141

Updates multiple dependencies to latest version. 

Please run
* cargo-audit audit
* cargo outdated

Before releasing new version  to protect against supply chain security vulnerabilities. 

Builds & passes all tests. Please review & run regression before merge.

Thank you, 
Marvin 